### PR TITLE
Implement fix in impression listener configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 nuget:
   account_feed: true
 
-version: 3.1.0
+version: 3.1.1
 
 before_build:
  - dotnet restore -s https://www.nuget.org/api/v2/

--- a/src/Splitio-net-core/Services/Client/Classes/RedisClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/RedisClient.cs
@@ -96,7 +96,10 @@ namespace Splitio.Services.Client.Classes
             var treatmentLog = new RedisTreatmentLog(impressionsCache);
             impressionListener = new AsynchronousImpressionListener();
             ((AsynchronousImpressionListener)impressionListener).AddListener(treatmentLog);
-            ((AsynchronousImpressionListener)impressionListener).AddListener(config.ImpressionListener);
+            if (config.ImpressionListener != null)
+            {
+                ((AsynchronousImpressionListener)impressionListener).AddListener(config.ImpressionListener);
+            }
         }
 
         private void BuildMetricsLog()

--- a/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
@@ -191,7 +191,10 @@ namespace Splitio.Services.Client.Classes
             treatmentLog = new SelfUpdatingTreatmentLog(treatmentSdkApiClient, TreatmentLogRefreshRate, impressionsCache);
             impressionListener = new AsynchronousImpressionListener();
             ((AsynchronousImpressionListener)impressionListener).AddListener(treatmentLog);
-            ((AsynchronousImpressionListener)impressionListener).AddListener(config.ImpressionListener);
+            if (config.ImpressionListener != null)
+            {
+                ((AsynchronousImpressionListener)impressionListener).AddListener(config.ImpressionListener);
+            }
         }
 
 

--- a/src/Splitio-net-core/Splitio-net-core.csproj
+++ b/src/Splitio-net-core/Splitio-net-core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
     <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Splitio-net-core</AssemblyName>
     <PackageId>Splitio-net-core</PackageId>
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splitio-net-core/Version.cs
+++ b/src/Splitio-net-core/Version.cs
@@ -2,7 +2,7 @@
 {
     public static class Version
     {
-        public static string SplitSdkVersion = "3.1.0";
+        public static string SplitSdkVersion = "3.1.1";
         public static string SplitSpecVersion = "1.0";
     }
 }


### PR DESCRIPTION
Net sdk was adding a custom impression listener to list, even if not configured.
Solution: Avoid adding custom impression listener if not configured