### PR TITLE
[Issue94] Invalid Api key causes high CPU usage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 nuget:
   account_feed: true
 
-version: 3.3.1
+version: 3.3.2-rc{build}
 
 configuration: Release
 

--- a/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
@@ -149,6 +149,8 @@ namespace Splitio.Services.Client.Classes
                             selfRefreshingSegmentFetcher.StartScheduler();
                             break;
                         }
+
+                        Task.Delay(500).Wait();
                     }
                 });
         }


### PR DESCRIPTION
# Reproducing the issue
I created a console app that instantiates the splitClient with an invalid API key and then just waits until the user press a key:
```
        static void Main(string[] args)
        {
            Console.WriteLine("Hello World!");
            var factory = new SplitFactory("REPLACEME", new ConfigurationOptions
            {
                FeaturesRefreshRate = 60,
            });
            var splitClient = factory.Client();

            Console.ReadKey();
        }
```

# Cause of the issue
When a `SelfRefreshingClient` is created, it creates some ApiClients and then starts a thread with a `while (true)` where it checks if the Sdk is ready and, in case it is, it starts a scheduler.
The issue is that if the API key is invalid, the Sdk would never be ready so it enters an infinite loop.

For fixing the issue I just added a Task.Delay for waiting a few milliseconds after checking if the Sdk is ready and thus avoiding so many CPU usage, but **THIS IS JUST A PATCH.**

It would be cleaner to just stop the thread after X unsuccessful retries of contacting the API. Or maybe after some specific API response but that would require a little more analysis and a small refactor.

FYI, the response status for an invalid API key is 404 instead of 401 or 403 so I don't know if we can use that for deciding. Imagine that if a client has an unstable connection he may get 404 with a valid key and I guess that in that case we would like to keep retrying