### PR TITLE
Fix appveyor build

### DIFF
--- a/Splitio-net-core-tests/Splitio-net-core-tests.csproj
+++ b/Splitio-net-core-tests/Splitio-net-core-tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.1" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
   </ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 nuget:
   account_feed: true
 
-version: 3.3.1
+version: 3.3.2-rc{build}
 
 configuration: Release
 

--- a/src/Splitio-net-core/Version.cs
+++ b/src/Splitio-net-core/Version.cs
@@ -2,7 +2,7 @@
 {
     public static class Version
     {
-        public static string SplitSdkVersion = "3.3.1";
+        public static string SplitSdkVersion = "3.3.2";
         public static string SplitSpecVersion = "1.0";
     }
 }


### PR DESCRIPTION
# Background
Appveyor build was failing

# Changes done
- Update version number
- Update Moq library since the previously used version had a dependency on a deprecated library