### PR TITLE
Use dynamic version number

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,11 @@ nuget:
 
 version: 3.3.2-rc{build}
 
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  package_version: '{version}'
+
 configuration: Release
 
 before_build:

--- a/src/Splitio-net-core/Version.cs
+++ b/src/Splitio-net-core/Version.cs
@@ -1,8 +1,10 @@
-﻿namespace Splitio
+﻿using System.Reflection;
+
+namespace Splitio
 {
     public static class Version
     {
-        public static string SplitSdkVersion = "3.3.2";
+        public static string SplitSdkVersion = typeof(Version).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
         public static string SplitSpecVersion = "1.0";
     }
 }


### PR DESCRIPTION
# Background
There are multiple places where the version number is being set so this change consists on using the appveyor build number for the Nuget package version number and for the assembly informational version, which is the one used in the SDK 