### PR TITLE
Fix segments timeouts

### DIFF
--- a/Splitio-net-core-tests/Integration Tests/SdkApiClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/SdkApiClientTests.cs
@@ -10,14 +10,13 @@ namespace Splitio_Tests.Integration_Tests
     {
         [TestMethod]
         [Ignore]
-        public void ExecuteGetSuccessful()
+        public async void ExecuteGetSuccessful()
         {
             //Arrange
             var baseUrl = "http://demo7064886.mockable.io";
             var httpHeader = new HTTPHeader()
             {
                 authorizationApiKey = "ABCD",
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "1",
@@ -26,7 +25,7 @@ namespace Splitio_Tests.Integration_Tests
             var SdkApiClient = new SdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SdkApiClient.ExecuteGet("/messages?item=msg1");
+            var result = await SdkApiClient.ExecuteGet("/messages?item=msg1");
 
             //Assert
             Assert.AreEqual(result.statusCode, HttpStatusCode.OK);
@@ -36,13 +35,12 @@ namespace Splitio_Tests.Integration_Tests
 
         [TestMethod]
         [Ignore]
-        public void ExecuteGetShouldReturnErrorNotAuthorized()
+        public async void ExecuteGetShouldReturnErrorNotAuthorized()
         {
             //Arrange
             var baseUrl = "http://demo7064886.mockable.io";
             var httpHeader = new HTTPHeader()
             {
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "1",
@@ -51,7 +49,7 @@ namespace Splitio_Tests.Integration_Tests
             var SdkApiClient = new SdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SdkApiClient.ExecuteGet("/messages?item=msg2");
+            var result = await SdkApiClient.ExecuteGet("/messages?item=msg2");
 
             //Assert
             Assert.AreEqual(result.statusCode, HttpStatusCode.Unauthorized);
@@ -59,14 +57,13 @@ namespace Splitio_Tests.Integration_Tests
 
         [TestMethod]
         [Ignore]
-        public void ExecuteGetShouldReturnNotFoundOnInvalidRequest()
+        public async void ExecuteGetShouldReturnNotFoundOnInvalidRequest()
         {
             //Arrange
             var baseUrl = "http://demo706abcd.mockable.io";
             var httpHeader = new HTTPHeader()
             {
                 authorizationApiKey = "ABCD",
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "1",
@@ -75,21 +72,20 @@ namespace Splitio_Tests.Integration_Tests
             var SdkApiClient = new SdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SdkApiClient.ExecuteGet("/messages?item=msg2");
+            var result = await SdkApiClient.ExecuteGet("/messages?item=msg2");
 
             //Assert
             Assert.AreEqual(result.statusCode, HttpStatusCode.NotFound);
         }
 
         [TestMethod]
-        public void ExecuteGetShouldReturnEmptyResponseOnInvalidURL()
+        public async void ExecuteGetShouldReturnEmptyResponseOnInvalidURL()
         {
             //Arrange
             var baseUrl = "http://demo70e.iio";
             var httpHeader = new HTTPHeader()
             {
                 authorizationApiKey = "ABCD",
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "1",
@@ -98,7 +94,7 @@ namespace Splitio_Tests.Integration_Tests
             var SdkApiClient = new SdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SdkApiClient.ExecuteGet("/messages?item=msg2");
+            var result = await SdkApiClient.ExecuteGet("/messages?item=msg2");
 
             //Assert
             Assert.IsNotNull(result);

--- a/Splitio-net-core-tests/Integration Tests/SelfRefreshingSegmentFetcherTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/SelfRefreshingSegmentFetcherTests.cs
@@ -42,7 +42,6 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
-                encoding = "gzip"
             };
             var sdkApiClient = new SegmentSdkApiClient(httpHeader, baseUrl, 10000, 10000);
             var apiSegmentChangeFetcher = new ApiSegmentChangeFetcher(sdkApiClient);

--- a/Splitio-net-core-tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
@@ -82,7 +82,6 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
-                encoding = "gzip"
             };
             var sdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
             var apiSplitChangeFetcher = new ApiSplitChangeFetcher(sdkApiClient);
@@ -121,7 +120,6 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
-                encoding = "gzip"
             };
             var sdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
             var apiSplitChangeFetcher = new ApiSplitChangeFetcher(sdkApiClient);

--- a/Splitio-net-core-tests/Integration Tests/SplitSdkApiClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/SplitSdkApiClientTests.cs
@@ -11,7 +11,7 @@ namespace Splitio_Tests.Integration_Tests
     {
         [TestMethod]
         [Ignore]
-        public void ExecuteFetchSplitChangesSuccessful()
+        public async void ExecuteFetchSplitChangesSuccessful()
         {
             //Arrange
             var baseUrl = "http://sdk-aws-staging.split.io/api/";
@@ -22,12 +22,11 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
-                encoding = "gzip"
             };
             var SplitSdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SplitSdkApiClient.FetchSplitChanges(-1);
+            var result = await SplitSdkApiClient.FetchSplitChanges(-1);
   
             //Assert
             Assert.IsTrue(result.Contains("splits"));
@@ -36,13 +35,12 @@ namespace Splitio_Tests.Integration_Tests
 
 
         [TestMethod]
-        public void ExecuteGetShouldReturnEmptyIfNotAuthorized()
+        public async void ExecuteGetShouldReturnEmptyIfNotAuthorized()
         {
             //Arrange
             var baseUrl = "https://sdk.aws.staging.split.io/api";
             var httpHeader = new HTTPHeader()
             {
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
@@ -51,7 +49,7 @@ namespace Splitio_Tests.Integration_Tests
             var SplitSdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SplitSdkApiClient.FetchSplitChanges(-1);
+            var result = await SplitSdkApiClient.FetchSplitChanges(-1);
 
             //Assert
             Assert.IsTrue(result == String.Empty);

--- a/Splitio-net-core-tests/Unit Tests/SegmentFetcher/ApiSegmentChangeFetcherUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/SegmentFetcher/ApiSegmentChangeFetcherUnitTests.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Splitio.Services.SegmentFetcher.Classes;
 using Moq;
 using Splitio.Services.SplitFetcher.Interfaces;
+using System.Threading.Tasks;
 
 namespace Splitio_Tests.Unit_Tests.SegmentFetcher
 {
@@ -10,13 +11,13 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
     public class ApiSegmentChangeFetcherUnitTests
     {
         [TestMethod]
-        public void FetchSegmentChangesSuccessfull()
+        public async void FetchSegmentChangesSuccessfull()
         {
             //Arrange
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
             .Setup(x=>x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(Task.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -26,11 +27,11 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': 1470947453877
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             
             //Act
-            var result = apiFetcher.Fetch("payed", -1);
+            var result = await apiFetcher.Fetch("payed", -1);
 
             //Assert
             Assert.IsNotNull(result);
@@ -42,7 +43,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
         }
 
         [TestMethod]
-        public void FetchSegmentChangesWithExcepionSouldReturnNull()
+        public async void FetchSegmentChangesWithExcepionSouldReturnNull()
         {
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
@@ -51,7 +52,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
            
             //Act
-            var result = apiFetcher.Fetch("payed", -1);
+            var result = await apiFetcher.Fetch("payed", -1);
 
             //Assert
             Assert.IsNull(result);

--- a/Splitio-net-core-tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentFetcherUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentFetcherUnitTests.cs
@@ -7,7 +7,7 @@ using Splitio.Domain;
 using Moq;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System.Threading;
-
+using System.Threading.Tasks;
 
 namespace Splitio_Tests.Unit_Tests.SegmentFetcher
 {
@@ -22,7 +22,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(Task.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -32,7 +32,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': 10001
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments = new ConcurrentDictionary<string, Segment>();
             var cache = new InMemorySegmentCache(segments);
@@ -55,7 +55,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(Task.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -65,7 +65,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': 10001
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments = new ConcurrentDictionary<string, Segment>();
             var cache = new InMemorySegmentCache(segments);

--- a/Splitio-net-core-tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentUnitTests.cs
@@ -7,6 +7,7 @@ using Splitio.Services.Client.Classes;
 using Splitio.Services.Cache.Classes;
 using System.Collections.Concurrent;
 using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio_Tests.Unit_Tests.SegmentFetcher
 {
@@ -42,7 +43,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(Task.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -52,7 +53,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': -1
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments = new ConcurrentDictionary<string, Segment>();
             var cache = new InMemorySegmentCache(segments);
@@ -73,7 +74,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(Task.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -83,7 +84,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': 10001
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments = new ConcurrentDictionary<string, Segment>();
             var cache = new InMemorySegmentCache(segments);

--- a/Splitio-net-core-tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
@@ -5,6 +5,7 @@ using Splitio.Services.SplitFetcher.Interfaces;
 using Splitio.Services.SplitFetcher.Classes;
 using System.Linq;
 using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio_Tests.Unit_Tests
 {
@@ -13,18 +14,18 @@ namespace Splitio_Tests.Unit_Tests
     {
         [TestMethod]
         [Description("Test a Json that changes its structure and is deserialized without exception. Contains: a field renamed, a field removed and a field added.")]
-        public void ExecuteJsonDeserializeSuccessfulWithChangeInJsonFormat()
+        public async void ExecuteJsonDeserializeSuccessfulWithChangeInJsonFormat()
         {
             //Arrange
             Mock<ISplitSdkApiClient> apiMock = new Mock<ISplitSdkApiClient>();
             apiMock
                 .Setup(x => x.FetchSplitChanges(-1))
-                .Returns("{\"splits\": [ { \"trafficType\": \"user\", \"name\": \"Reset_Seed_UI\", \"seed\": 1552577712, \"status\": \"ACTIVE\", \"defaultTreatment\": \"off\", \"changeNumber\": 1469827821322, \"conditions\": [ { \"matcherGroup\": { \"combiner\": \"AND\", \"matchers\": [ { \"keySelector\": { \"trafficType\": \"user\", \"attribute\": null }, \"matcherType\": \"ALL_KEYS\", \"negate\": false, \"userDefinedSegmentMatcherData\": null, \"whitelistMatcherData\": null, \"unaryNumericMatcherData\": null, \"betweenMatcherData\": null } ] }, \"partitions\": [ { \"treatment\": \"on\", \"size\": 100 }, { \"treatment\": \"off\", \"size\": 0, \"addedField\": \"test\"  } ] } ] } ], \"since\": 1469817846929, \"till\": 1469827821322 }\r\n");
+                .Returns(Task.FromResult("{\"splits\": [ { \"trafficType\": \"user\", \"name\": \"Reset_Seed_UI\", \"seed\": 1552577712, \"status\": \"ACTIVE\", \"defaultTreatment\": \"off\", \"changeNumber\": 1469827821322, \"conditions\": [ { \"matcherGroup\": { \"combiner\": \"AND\", \"matchers\": [ { \"keySelector\": { \"trafficType\": \"user\", \"attribute\": null }, \"matcherType\": \"ALL_KEYS\", \"negate\": false, \"userDefinedSegmentMatcherData\": null, \"whitelistMatcherData\": null, \"unaryNumericMatcherData\": null, \"betweenMatcherData\": null } ] }, \"partitions\": [ { \"treatment\": \"on\", \"size\": 100 }, { \"treatment\": \"off\", \"size\": 0, \"addedField\": \"test\"  } ] } ] } ], \"since\": 1469817846929, \"till\": 1469827821322 }\r\n"));
 
             ApiSplitChangeFetcher apiSplitChangeFetcher = new ApiSplitChangeFetcher(apiMock.Object);
 
             //Act
-            var result = apiSplitChangeFetcher.Fetch(-1);
+            var result = await apiSplitChangeFetcher.Fetch(-1);
 
             //Assert
             Assert.IsTrue(result != null);
@@ -32,13 +33,13 @@ namespace Splitio_Tests.Unit_Tests
         }
 
         [TestMethod]
-        public void FetchSplitChangesSuccessfull()
+        public async void FetchSplitChangesSuccessfull()
         {
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSplitChanges(It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(Task.FromResult(@"{
                           'splits': [
                             {
                               'trafficTypeName': 'user',
@@ -83,11 +84,11 @@ namespace Splitio_Tests.Unit_Tests
                           ],
                           'since': -1,
                           'till': 1470855828956
-                        }");
+                        }"));
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1);
 
             //Assert
             Assert.IsNotNull(result);
@@ -104,13 +105,13 @@ namespace Splitio_Tests.Unit_Tests
         }
 
         [TestMethod]
-        public void FetchSplitChangesSuccessfullVerifyAlgorithmIsLegacy()
+        public async void FetchSplitChangesSuccessfullVerifyAlgorithmIsLegacy()
         {
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSplitChanges(It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(Task.FromResult(@"{
                           'splits': [
                             {
                               'trafficTypeName': 'user',
@@ -156,11 +157,11 @@ namespace Splitio_Tests.Unit_Tests
                           ],
                           'since': -1,
                           'till': 1470855828956
-                        }");
+                        }"));
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1);
 
             //Assert
             Assert.IsNotNull(result);
@@ -169,13 +170,13 @@ namespace Splitio_Tests.Unit_Tests
         }
 
         [TestMethod]
-        public void FetchSplitChangesSuccessfullVerifyAlgorithmIsMurmur()
+        public async void FetchSplitChangesSuccessfullVerifyAlgorithmIsMurmur()
         {
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSplitChanges(It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(Task.FromResult(@"{
                           'splits': [
                             {
                               'trafficTypeName': 'user',
@@ -221,11 +222,11 @@ namespace Splitio_Tests.Unit_Tests
                           ],
                           'since': -1,
                           'till': 1470855828956
-                        }");
+                        }"));
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1);
 
             //Assert
             Assert.IsNotNull(result);
@@ -234,7 +235,7 @@ namespace Splitio_Tests.Unit_Tests
         }
 
         [TestMethod]
-        public void FetchSplitChangesWithExcepionSouldReturnNull()
+        public async void FetchSplitChangesWithExcepionSouldReturnNull()
         {
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
@@ -243,7 +244,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1);
 
             //Assert
             Assert.IsNull(result);

--- a/src/Splitio-net-core/CommonLibraries/HTTPHeader.cs
+++ b/src/Splitio-net-core/CommonLibraries/HTTPHeader.cs
@@ -8,6 +8,5 @@ namespace Splitio.CommonLibraries
         public string splitSDKSpecVersion { get; set; }
         public string splitSDKMachineName { get; set; }
         public string splitSDKMachineIP { get; set; }
-        public string encoding { get; set; } 
     }
 }

--- a/src/Splitio-net-core/CommonLibraries/ISdkApiClient.cs
+++ b/src/Splitio-net-core/CommonLibraries/ISdkApiClient.cs
@@ -1,10 +1,11 @@
-﻿
+﻿using System.Threading.Tasks;
+
 namespace Splitio.CommonLibraries
 {
     public interface ISdkApiClient
     {
-        HTTPResult ExecuteGet(string requestUri);
+        Task<HTTPResult> ExecuteGet(string requestUri);
 
-        HTTPResult ExecutePost(string requestUri, string data);
+        Task<HTTPResult> ExecutePost(string requestUri, string data);
     }
 }

--- a/src/Splitio-net-core/CommonLibraries/SdkApiClient.cs
+++ b/src/Splitio-net-core/CommonLibraries/SdkApiClient.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Splitio.CommonLibraries
 {
@@ -16,18 +17,11 @@ namespace Splitio.CommonLibraries
 
         public SdkApiClient (HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null)
         {
-            if (header.encoding == "gzip")
+            var handler = new HttpClientHandler()
             {
-                HttpClientHandler handler = new HttpClientHandler()
-                {
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-                };
-                httpClient = new HttpClient(handler);
-            }
-            else
-            {
-                httpClient = new HttpClient();
-            }
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+            httpClient = new HttpClient(handler);
 
             httpClient.BaseAddress = new Uri(baseUrl);
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", header.authorizationApiKey);
@@ -41,7 +35,7 @@ namespace Splitio.CommonLibraries
             {
                 httpClient.DefaultRequestHeaders.Add("SplitSDKMachineIP", header.splitSDKMachineIP);
             }
-            httpClient.DefaultRequestHeaders.Add("Accept-Encoding", header.encoding);
+            httpClient.DefaultRequestHeaders.Add("Accept-Encoding", "gzip");
             httpClient.DefaultRequestHeaders.Add("Keep-Alive", "true");
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
@@ -51,16 +45,16 @@ namespace Splitio.CommonLibraries
             this.metricsLog = metricsLog;
         }
 
-        public virtual HTTPResult ExecuteGet(string requestUri)
+        public virtual async Task<HTTPResult> ExecuteGet(string requestUri)
         {
             var result = new HTTPResult();
             try
             {
-                var task = httpClient.GetAsync(requestUri);
-                task.Wait();
-                var response = task.Result;
-                result.statusCode = response.StatusCode;
-                result.content = response.Content.ReadAsStringAsync().Result;                
+                using (var response = await httpClient.GetAsync(requestUri))
+                {
+                    result.statusCode = response.StatusCode;
+                    result.content = response.Content.ReadAsStringAsync().Result;
+                }
             }
             catch(Exception e)
             {
@@ -69,16 +63,16 @@ namespace Splitio.CommonLibraries
             return result;
         }
 
-        public virtual HTTPResult ExecutePost(string requestUri, string data)
+        public virtual async Task<HTTPResult> ExecutePost(string requestUri, string data)
         {
             var result = new HTTPResult();
             try
             {
-                var task = httpClient.PostAsync(requestUri, new StringContent(data, Encoding.UTF8, "application/json"));
-                task.Wait();
-                var response = task.Result;
-                result.statusCode = response.StatusCode;
-                result.content = response.Content.ReadAsStringAsync().Result;
+                using (var response = await httpClient.PostAsync(requestUri, new StringContent(data, Encoding.UTF8, "application/json")))
+                {
+                    result.statusCode = response.StatusCode;
+                    result.content = response.Content.ReadAsStringAsync().Result;
+                }
             }
             catch (Exception e)
             {

--- a/src/Splitio-net-core/Services/Client/Classes/JSONFileClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/JSONFileClient.cs
@@ -22,7 +22,9 @@ namespace Splitio.Services.Client.Classes
             var segmentFetcher = new JSONFileSegmentFetcher(segmentsFilePath, segmentCache);
             var splitParser = new InMemorySplitParser(segmentFetcher, segmentCache);
             var splitChangeFetcher = new JSONFileSplitChangeFetcher(splitsFilePath);
-            var splitChangesResult = splitChangeFetcher.Fetch(-1);
+            var task = splitChangeFetcher.Fetch(-1);
+            task.Wait();
+            var splitChangesResult = task.Result;
             var parsedSplits = new ConcurrentDictionary<string, ParsedSplit>();
             foreach (Split split in splitChangesResult.splits)
                 parsedSplits.TryAdd(split.name, splitParser.Parse(split));         

--- a/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
@@ -240,7 +240,6 @@ namespace Splitio.Services.Client.Classes
         {
             var header = new HTTPHeader();
             header.authorizationApiKey = ApiKey;
-            header.encoding = HttpEncoding;
             header.splitSDKVersion = SdkVersion;
             header.splitSDKSpecVersion = SdkSpecVersion;
             header.splitSDKMachineName = SdkMachineName;

--- a/src/Splitio-net-core/Services/Events/Classes/EventSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Events/Classes/EventSdkApiClient.cs
@@ -16,14 +16,14 @@ namespace Splitio.Services.Events.Classes
 
         public EventSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
 
-        public void SendBulkEvents(List<Event> events)
+        public async void SendBulkEvents(List<Event> events)
         {
             var eventsJson = JsonConvert.SerializeObject(events, new JsonSerializerSettings
             {
                 NullValueHandling = NullValueHandling.Ignore
             });
 
-            var response = ExecutePost(EventsUrlTemplate, eventsJson);
+            var response = await ExecutePost(EventsUrlTemplate, eventsJson);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(string.Format("Http status executing SendBulkEvents: {0} - {1}", response.statusCode.ToString(), response.content));

--- a/src/Splitio-net-core/Services/Impressions/Classes/TreatmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Impressions/Classes/TreatmentSdkApiClient.cs
@@ -17,11 +17,11 @@ namespace Splitio.Services.Impressions.Classes
 
         public TreatmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
 
-        public void SendBulkImpressions(List<KeyImpression> impressions)
+        public async void SendBulkImpressions(List<KeyImpression> impressions)
         {
             var impressionsJson = ConvertToJson(impressions);
 
-            var response = ExecutePost(TestImpressionsUrlTemplate, impressionsJson);
+            var response = await ExecutePost(TestImpressionsUrlTemplate, impressionsJson);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(string.Format("Http status executing SendBulkImpressions: {0} - {1}", response.statusCode.ToString(), response.content));

--- a/src/Splitio-net-core/Services/Metrics/Classes/MetricsSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Metrics/Classes/MetricsSdkApiClient.cs
@@ -13,27 +13,27 @@ namespace Splitio.Services.Metrics.Classes
 
         public MetricsSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
 
-        public void SendCountMetrics(string metrics)
+        public async void SendCountMetrics(string metrics)
         {
-            var response = ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "counters"), metrics);
+            var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "counters"), metrics);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(string.Format("Http status executing SendCountMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }
         }
 
-        public void SendTimeMetrics(string metrics)
+        public async void SendTimeMetrics(string metrics)
         {
-            var response = ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "times"), metrics);
+            var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "times"), metrics);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(string.Format("Http status executing SendTimeMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }
         }
 
-        public void SendGaugeMetrics(string metrics)
+        public async void SendGaugeMetrics(string metrics)
         {
-            var response = ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "gauge"), metrics);
+            var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "gauge"), metrics);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(string.Format("Http status executing SendGaugeMetrics: {0} - {1}", response.statusCode.ToString(), response.content));

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
@@ -2,6 +2,7 @@
 using Splitio.Domain;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using Splitio.Services.SplitFetcher.Interfaces;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -14,9 +15,9 @@ namespace Splitio.Services.SegmentFetcher.Classes
             this.apiClient = apiClient;
         }
 
-        protected override SegmentChange FetchFromBackend(string name, long since)
+        protected override async Task<SegmentChange> FetchFromBackend(string name, long since)
         {
-            var fetchResult = apiClient.FetchSegmentChanges(name, since);
+            var fetchResult = await apiClient.FetchSegmentChanges(name, since);
 
             var segmentChange = JsonConvert.DeserializeObject<SegmentChange>(fetchResult);
             return segmentChange;

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
@@ -2,6 +2,7 @@
 using Splitio.Domain;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using System;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -10,13 +11,13 @@ namespace Splitio.Services.SegmentFetcher.Classes
         private SegmentChange segmentChange;
         private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentChangeFetcher));
 
-        protected abstract SegmentChange FetchFromBackend(string name, long since);
+        protected abstract Task<SegmentChange> FetchFromBackend(string name, long since);
 
-        public SegmentChange Fetch(string name, long since)
+        public async Task<SegmentChange> Fetch(string name, long since)
         {
             try
             {
-                segmentChange = FetchFromBackend(name, since);
+                segmentChange = await FetchFromBackend(name, since);
             }
             catch(Exception e)
             {

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -37,6 +37,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                         metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
                     }
 
+                    Log.Debug($"FetchSegmentChanges with name '{name}' took {clock.ElapsedMilliseconds} milliseconds using uri '{requestUri}'");
                     return response.content;
                 }
                 else

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -5,6 +5,7 @@ using Splitio.Services.SplitFetcher.Interfaces;
 using System;
 using System.Diagnostics;
 using System.Net;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -20,14 +21,14 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
         public SegmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
 
-        public string FetchSegmentChanges(string name, long since)
+        public async Task<string> FetchSegmentChanges(string name, long since)
         {
             var clock = new Stopwatch();
             clock.Start();
             try
             {
                 var requestUri = GetRequestUri(name, since);
-                var response = ExecuteGet(requestUri);
+                var response = await ExecuteGet(requestUri);
                 if (response.statusCode == HttpStatusCode.OK)
                 {
                     if (metricsLog != null)

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
@@ -24,7 +24,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
             gates.RegisterSegment(name);
         }
 
-        public void RefreshSegment()
+        public async void RefreshSegment()
         {        
             while (true)
             {
@@ -32,7 +32,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
                 try
                 {
-                    var response = segmentChangeFetcher.Fetch(name, changeNumber);
+                    var response = await segmentChangeFetcher.Fetch(name, changeNumber);
                     if (response == null)
                     {
                         break;

--- a/src/Splitio-net-core/Services/SegmentFetcher/Interfaces/ISegmentChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Interfaces/ISegmentChangeFetcher.cs
@@ -1,9 +1,10 @@
 ﻿using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Interfaces
 {
     public interface ISegmentChangeFetcher
     {
-        SegmentChange Fetch(string name, long change_number);
+        Task<SegmentChange> Fetch(string name, long change_number);
     }
 }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Interfaces/ISegmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Interfaces/ISegmentSdkApiClient.cs
@@ -1,7 +1,9 @@
-﻿namespace Splitio.Services.SplitFetcher.Interfaces
+﻿using System.Threading.Tasks;
+
+namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISegmentSdkApiClient
     {
-        string FetchSegmentChanges(string name, long since);
+        Task<string> FetchSegmentChanges(string name, long since);
     }
 }

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Splitio.Domain;
 using Splitio.Services.SplitFetcher.Interfaces;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -13,9 +14,9 @@ namespace Splitio.Services.SplitFetcher.Classes
             this.apiClient = apiClient;
         }
 
-        protected override SplitChangesResult FetchFromBackend(long since)
+        protected override async Task<SplitChangesResult> FetchFromBackend(long since)
         {
-            var fetchResult = apiClient.FetchSplitChanges(since);
+            var fetchResult = await apiClient.FetchSplitChanges(since);
 
             var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(fetchResult);
             return splitChangesResult;

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/JSONFileSplitChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/JSONFileSplitChangeFetcher.cs
@@ -3,6 +3,7 @@ using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -15,11 +16,11 @@ namespace Splitio.Services.SplitFetcher.Classes
             this.filePath = filePath;
         }
 
-        protected override SplitChangesResult FetchFromBackend(long since)
+        protected override async Task<SplitChangesResult> FetchFromBackend(long since)
         {
             var json = File.ReadAllText(filePath);
             var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(json);
-            return splitChangesResult;
+            return await Task.FromResult(splitChangesResult);
         }
     }
 }

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
@@ -92,14 +92,14 @@ namespace Splitio.Services.SplitFetcher.Classes
             }
         }
 
-        private void RefreshSplits()
+        private async void RefreshSplits()
         {
             while (true)
             {
                 var changeNumber = splitCache.GetChangeNumber();
                 try
                 {
-                    var result = splitChangeFetcher.Fetch(changeNumber);
+                    var result = await splitChangeFetcher.Fetch(changeNumber);
                     if (result == null)
                     {
                         break;

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
@@ -2,6 +2,7 @@
 using Splitio.Domain;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -10,13 +11,13 @@ namespace Splitio.Services.SplitFetcher.Classes
         private SplitChangesResult splitChanges;
         private static readonly ILog Log = LogManager.GetLogger(typeof(SplitChangeFetcher));
 
-        protected abstract SplitChangesResult FetchFromBackend(long since);
+        protected abstract Task<SplitChangesResult> FetchFromBackend(long since);
 
-        public SplitChangesResult Fetch(long since)
+        public async Task<SplitChangesResult> Fetch(long since)
         {
             try
             {
-                splitChanges = FetchFromBackend(since);
+                splitChanges = await FetchFromBackend(since);
             }
             catch(Exception e)
             {

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
@@ -5,6 +5,7 @@ using Splitio.Services.SplitFetcher.Interfaces;
 using System;
 using System.Diagnostics;
 using System.Net;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -20,14 +21,14 @@ namespace Splitio.Services.SplitFetcher.Classes
 
         public SplitSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
 
-        public string FetchSplitChanges(long since)
+        public async Task<string> FetchSplitChanges(long since)
         {
             var clock = new Stopwatch();
             clock.Start();
             try
             {
                 var requestUri = GetRequestUri(since);
-                var response = ExecuteGet(requestUri);
+                var response = await ExecuteGet(requestUri);
                 if (response.statusCode == HttpStatusCode.OK)
                 {
                     if (metricsLog != null)

--- a/src/Splitio-net-core/Services/SplitFetcher/Interfaces/ISplitChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Interfaces/ISplitChangeFetcher.cs
@@ -1,9 +1,10 @@
 ﻿using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISplitChangeFetcher
     {
-        SplitChangesResult Fetch(long since);
+        Task<SplitChangesResult> Fetch(long since);
     }
 }

--- a/src/Splitio-net-core/Services/SplitFetcher/Interfaces/ISplitSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Interfaces/ISplitSdkApiClient.cs
@@ -1,7 +1,9 @@
-﻿namespace Splitio.Services.SplitFetcher.Interfaces
+﻿using System.Threading.Tasks;
+
+namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISplitSdkApiClient
     {
-        string FetchSplitChanges(long since);
+        Task<string> FetchSplitChanges(long since);
     }
 }


### PR DESCRIPTION
# Changes done
- Use async/await methods for API requests
- Change affected tests
- Remove unused `encoding` property since it was always hardcoded for using GZIP