### PR TITLE
Use default if no file name is configured

### DIFF
--- a/src/Splitio-net-core/Services/Client/Classes/LocalhostClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/LocalhostClient.cs
@@ -11,6 +11,7 @@ namespace Splitio.Services.Client.Classes
 {
     public class LocalhostClient : SplitClient
     {
+        private const string DefaultSplitFileName = ".split";
         private static readonly ILog Log = LogManager.GetLogger(typeof(LocalhostClient));
 
         private FileSystemWatcher watcher;
@@ -51,7 +52,7 @@ namespace Splitio.Services.Client.Classes
             }
             var home = Environment.GetEnvironmentVariable("USERPROFILE");
 
-            var fullPath = Path.Combine(home, filePath);
+            var fullPath = Path.Combine(home, filePath ?? DefaultSplitFileName);
             if (File.Exists(fullPath))
             {
                 return fullPath;


### PR DESCRIPTION
# Changes done
- Use default filename `.split`  if no filename is configured