### PR TITLE
Input validation

### DIFF
--- a/Splitio-net-core-tests/Integration Tests/JSONFileClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/JSONFileClientTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Common.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
@@ -14,12 +15,14 @@ namespace Splitio_Tests.Integration_Tests
     [TestClass]
     public class JSONFileClientTests
     {
+        private Mock<ILog> _logMock = new Mock<ILog>();
+
         [TestMethod]
         [DeploymentItem(@"Resources\splits_staging_3.json")]
         public void ExecuteGetTreatmentOnFailedParsingSplitShouldReturnControl()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "fail", null);
@@ -34,7 +37,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnFailedParsingSplitShouldNotAffectOtherSplits()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "asd", null);
@@ -49,7 +52,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnDeletedSplitShouldReturnControl()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "asd", null);
@@ -71,7 +74,7 @@ namespace Splitio_Tests.Integration_Tests
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
             var splitCacheMock = new Mock<ISplitCache>();
             splitCacheMock.Setup(x => x.GetSplit(It.IsAny<string>())).Throws<Exception>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, splitCacheMock.Object, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, splitCacheMock.Object, treatmentLogMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "asd", null);
@@ -86,7 +89,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatments()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object);
             List<string> features = new List<string>();
             features.Add("fail");
             features.Add("asd");
@@ -111,7 +114,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentsWithBucketing()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object);
             List<string> features = new List<string>();
             features.Add("fail");
             features.Add("asd");
@@ -139,7 +142,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnRemovedUserFromSegmentShouldReturnOff()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", @"Resources\segment_payed.json");
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", @"Resources\segment_payed.json", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("abcdz", "test_jw2", null);
@@ -159,7 +162,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithOnOffOnPartition()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("01", "Test_on_off_on", null);
@@ -181,7 +184,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithTrafficAllocation()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("01", "Traffic_Allocation_UI", null);
@@ -203,7 +206,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithTrafficAllocationWhenAllocationIsDifferentThan100()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("01", "Traffic_Allocation_UI3", null);
@@ -225,7 +228,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithSegmentNotInitialized()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object);
 
             //Act           
             //feature test_jw2 has UserDefinedSegmentMatcher 
@@ -244,7 +247,7 @@ namespace Splitio_Tests.Integration_Tests
         {
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, null, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, null, treatmentLogMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "test_jw3", null);
@@ -259,7 +262,7 @@ namespace Splitio_Tests.Integration_Tests
         {
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, null, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, null, treatmentLogMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "whitelisting_elements", null);
@@ -275,7 +278,7 @@ namespace Splitio_Tests.Integration_Tests
         {
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, null, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, null, treatmentLogMock.Object);
 
             //Act           
             client.RemoveSplitFromCache("asd");
@@ -293,7 +296,7 @@ namespace Splitio_Tests.Integration_Tests
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
             var splitCacheMock = new Mock<ISplitCache>();
             splitCacheMock.Setup(x => x.GetSplit(It.IsAny<string>())).Throws<Exception>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, splitCacheMock.Object, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, splitCacheMock.Object, treatmentLogMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "asd", null);
@@ -308,7 +311,7 @@ namespace Splitio_Tests.Integration_Tests
         {
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
-            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "", null, null, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "", _logMock.Object, null, null, treatmentLogMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "Traffic_Allocation_UI2", null);
@@ -323,7 +326,7 @@ namespace Splitio_Tests.Integration_Tests
         {
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, null, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, null, treatmentLogMock.Object);
 
             //Act           
             var result = client.GetTreatment("db765170-e9f2-11e5-885c-c2f58c3a47a7", "Segments_Restructuring_UI", null);
@@ -338,7 +341,7 @@ namespace Splitio_Tests.Integration_Tests
         {
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, null, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, null, treatmentLogMock.Object);
 
             //Act           
             var result = client.GetTreatment("xs", "Unknown_Matcher", null);
@@ -353,7 +356,7 @@ namespace Splitio_Tests.Integration_Tests
         {
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, null, treatmentLogMock.Object, isLabelsEnabled: false);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, null, treatmentLogMock.Object, isLabelsEnabled: false);
 
             //Act           
             var result = client.GetTreatment("db765170-e9f2-11e5-885c-c2f58c3a47a7", "Segments_Restructuring_UI", null);
@@ -368,7 +371,7 @@ namespace Splitio_Tests.Integration_Tests
         {
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
-            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", null, null, treatmentLogMock.Object);
+            var client = new JSONFileClient(@"Resources\splits_staging_3.json", "", _logMock.Object, null, null, treatmentLogMock.Object);
 
             //Act           
             var key = new Key("db765170-e9f2-11e5-885c-c2f58c3a47a7", "ab765170-e9f2-11e5-885c-c2f58c3a47a7");
@@ -384,7 +387,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentWithBooleanAttribute()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "", null, null);
+            var client = new JSONFileClient(@"Resources\splits_staging_4.json", "", _logMock.Object, null, null);
 
             var attributes = new Dictionary<string, object>();
             attributes.Add("boolean_attribute", true);
@@ -402,7 +405,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentWithSetMatcherReturnsOff()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "", _logMock.Object);
 
             var attributes = new Dictionary<string, object>();
             attributes.Add("permissions", new List<string>() { "create" });
@@ -420,7 +423,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentWithSetMatcherReturnsOn()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "", _logMock.Object);
 
             var attributes = new Dictionary<string, object>();
             attributes.Add("permissions", new List<string>() { "execute" });
@@ -438,7 +441,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentWithStringMatcherReturnsOff()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "", _logMock.Object);
 
             var attributes = new Dictionary<string, object>();
             attributes.Add("st", "permission");
@@ -456,7 +459,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentWithStringMatcherReturnsOn()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "", _logMock.Object);
 
             var attributes = new Dictionary<string, object>();
             attributes.Add("st", "allow");
@@ -475,7 +478,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentWithDependencyMatcherReturnsOn()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("fake_user_id_1", "test_dependency", null);
@@ -490,7 +493,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentWithDependencyMatcherReturnsOff()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "", _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("fake_user_id_6", "test_dependency", null);
@@ -506,7 +509,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentsWithDependencyMatcherReturnsOn()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "", _logMock.Object);
 
             //Act           
             var features = new List<string>();
@@ -525,7 +528,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentsWithDependencyMatcherWithAttributesReturnsOn()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "", _logMock.Object);
 
             //Act           
             var features = new List<string>();
@@ -548,7 +551,7 @@ namespace Splitio_Tests.Integration_Tests
             //Arrange
             var queue = new BlockingQueue<KeyImpression>(10);
             var impressionsCache = new InMemorySimpleCache<KeyImpression>(queue);
-            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "", null, null, new SelfUpdatingTreatmentLog(null, 1000, impressionsCache));
+            var client = new JSONFileClient(@"Resources\splits_staging_6.json", "", _logMock.Object, null, null, new SelfUpdatingTreatmentLog(null, 1000, impressionsCache));
 
             //Act           
             var result = client.GetTreatment("test", "test_dependency_segment", null);
@@ -566,7 +569,7 @@ namespace Splitio_Tests.Integration_Tests
         public void DestroySucessfully()
         {
             //Arrange
-            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "");
+            var client = new JSONFileClient(@"Resources\splits_staging_5.json", "", _logMock.Object);
 
             var attributes = new Dictionary<string, object>();
             attributes.Add("permissions", new List<string>() { "execute" });

--- a/Splitio-net-core-tests/Integration Tests/LocalhostClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/LocalhostClientTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Common.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using Splitio.Services.Client.Classes;
 using System;
 using System.IO;
@@ -9,12 +11,14 @@ namespace Splitio_Tests.Integration_Tests
     [TestClass]
     public class LocalhostClientTests
     {
+        private Mock<ILog> _logMock = new Mock<ILog>();
+
         [DeploymentItem(@"Resources\test.splits")]
         [TestMethod]
         public void GetTreatmentSuccessfully()
         {
             //Arrange
-            var client = new LocalhostClient(@"Resources\test.splits");
+            var client = new LocalhostClient(@"Resources\test.splits", _logMock.Object);
 
             //Act
             var result1 = client.GetTreatment("", "double_writes_to_cassandra");
@@ -35,7 +39,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentSuccessfullyWhenUpdatingSplitsFile()
         {
             //Arrange
-            var client = new LocalhostClient(@"Resources\test.splits");
+            var client = new LocalhostClient(@"Resources\test.splits", _logMock.Object);
             File.AppendAllText(@"Resources\test.splits", Environment.NewLine +"other_test_feature2     off" + Environment.NewLine);
             Thread.Sleep(50);
 
@@ -61,7 +65,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ClientDestroySuccessfully()
         {
             //Arrange
-            var client = new LocalhostClient(@"Resources\test.splits");
+            var client = new LocalhostClient(@"Resources\test.splits", _logMock.Object);
 
 
             //Act

--- a/Splitio-net-core-tests/Integration Tests/RedisClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/RedisClientTests.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using Splitio.Domain;
 using Splitio.Redis.Services.Client.Classes;
 using Splitio.Redis.Services.Cache.Classes;
+using Common.Logging;
+using Moq;
 
 namespace Splitio_Tests.Integration_Tests
 {
@@ -12,7 +14,8 @@ namespace Splitio_Tests.Integration_Tests
     [Ignore]
     public class RedisClientTests
     {
-        ConfigurationOptions config;
+        private ConfigurationOptions config;
+        private Mock<ILog> _logMock = new Mock<ILog>();
 
         [TestInitialize]
         public void Initialization()
@@ -29,7 +32,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnInexistentSplitShouldReturnControl()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act           
             var result = client.GetTreatment("test", "fail", null);
@@ -43,7 +46,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithSegmentShouldReturnOnIfExistent()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act           
             //feature test_jw2 has UserDefinedSegmentMatcher 
@@ -59,7 +62,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithSegmentShouldReturnOffIfNotExistent()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act           
             //feature test_jw2 has UserDefinedSegmentMatcher 
@@ -77,7 +80,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnKilledSplitReturnsDefaultTreatment()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act    
             //Default treatment is off
@@ -92,7 +95,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentAndUsingBucketingKeyForTreatment()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act           
             var key = new Key("abcdz", "2f726442-abbd-43f0-8373-ada456cff612");
@@ -107,7 +110,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentAndEmptyBucketingKeyShouldReturnControl()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act           
             var key = new Key("abcdz", "");
@@ -122,7 +125,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnRemovedUserFromSegmentShouldReturnOff()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
             var cache = new RedisSegmentCache(new RedisAdapter("localhost", "6379", ""));
             
             //Act           
@@ -146,7 +149,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithDateMatcherReturnOn()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act           
             Dictionary<string, object> data = new Dictionary<string, object>();
@@ -162,7 +165,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithDateMatcherReturnOff()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act           
             Dictionary<string, object> data = new Dictionary<string, object>();
@@ -178,7 +181,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ExecuteGetTreatmentOnSplitWithWhitelistMatcherReturnOn()
         {
             //Arrange
-            var client = new RedisClient(config);
+            var client = new RedisClient(config, _logMock.Object);
 
             //Act           
             Dictionary<string, object> data = new Dictionary<string, object>();

--- a/Splitio-net-core-tests/Unit Tests/Client/LocalhostClientForTesting.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/LocalhostClientForTesting.cs
@@ -1,4 +1,5 @@
-﻿using Splitio.Domain;
+﻿using Common.Logging;
+using Splitio.Domain;
 using Splitio.Services.Client.Classes;
 using Splitio.Services.EngineEvaluator;
 using Splitio.Services.Shared.Interfaces;
@@ -7,7 +8,7 @@ namespace Splitio_Tests.Unit_Tests.Client
 {
     public class LocalhostClientForTesting : LocalhostClient
     {
-        public LocalhostClientForTesting(string filePath, Splitter splitter = null) : base(filePath, splitter) { }
+        public LocalhostClientForTesting(string filePath, ILog log, Splitter splitter = null) : base(filePath, log, splitter) { }
 
         public IListener<Event> GetEventListener()
         {

--- a/Splitio-net-core-tests/Unit Tests/Client/LocalhostClientUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/LocalhostClientUnitTests.cs
@@ -1,18 +1,22 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Splitio.Services.Client.Classes;
+﻿using Common.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using Splitio.Domain;
+using Splitio.Services.Client.Classes;
 
 namespace Splitio_Tests.Unit_Tests.Client
 {
     [TestClass]
     public class LocalhostClientUnitTests
     {
+        private Mock<ILog> _logMock = new Mock<ILog>();
+
         [TestMethod]
         [DeploymentItem(@"Resources\test.splits")]
         public void GetTreatmentShouldReturnControlIfSplitNotFound()
         {
             //Arrange
-            var splitClient = new LocalhostClient(@"Resources\test.splits");
+            var splitClient = new LocalhostClient(@"Resources\test.splits", _logMock.Object);
             
             //Act
             var result = splitClient.GetTreatment("test", "test");
@@ -25,7 +29,7 @@ namespace Splitio_Tests.Unit_Tests.Client
         [DeploymentItem(@"Resources\test.splits")]
         public void GetTreatmentShouldRunAsSingleKeyUsingNullBucketingKey()
         {
-            var splitClient = new LocalhostClient(@"Resources\test.splits");
+            var splitClient = new LocalhostClient(@"Resources\test.splits", _logMock.Object);
 
             //Act
             var key = new Key("test", null);
@@ -40,7 +44,7 @@ namespace Splitio_Tests.Unit_Tests.Client
         public void TrackShouldNotStoreEvents()
         {
             //Arrange
-            var splitClient = new LocalhostClientForTesting(@"Resources\test.splits");
+            var splitClient = new LocalhostClientForTesting(@"Resources\test.splits", _logMock.Object);
 
             //Act
             var result = splitClient.Track("test", "test", "test");

--- a/Splitio-net-core-tests/Unit Tests/Client/SplitClientForTesting.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitClientForTesting.cs
@@ -1,0 +1,14 @@
+﻿using Common.Logging;
+using Splitio.Services.Client.Classes;
+
+namespace Splitio_Tests.Unit_Tests.Client
+{
+    public class SplitClientForTesting : SplitClient
+    {
+        public SplitClientForTesting(ILog log) : base(log) { }
+
+        public override void Destroy()
+        {
+        }
+    }
+}

--- a/Splitio-net-core-tests/Unit Tests/Client/SplitClientUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitClientUnitTests.cs
@@ -1,0 +1,87 @@
+﻿using Common.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Splitio.Domain;
+
+namespace Splitio_Tests.Unit_Tests.Client
+{
+    [TestClass]
+    public class SplitClientUnitTests
+    {
+        private SplitClientForTesting _splitClientForTesting;
+        private Mock<ILog> _logMock = new Mock<ILog>();
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            // Arrange
+            _splitClientForTesting = new SplitClientForTesting(_logMock.Object);
+        }
+
+        [TestMethod]
+        public void GetTreatment_ShouldReturnControl_WithNullKey()
+        {
+            // Act
+            var result = _splitClientForTesting.GetTreatment((string)null, string.Empty);
+
+            // Assert
+            Assert.AreEqual("control", result);
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void GetTreatment_ShouldReturnControl_WithNullMatchingKey()
+        {
+            // Act
+            var result = _splitClientForTesting.GetTreatment(new Key(null, string.Empty), string.Empty);
+
+            // Assert
+            Assert.AreEqual("control", result);
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void GetTreatment_ShouldReturnControl_WithNullMatchingAndBucketingKey()
+        {
+            // Act
+            var result = _splitClientForTesting.GetTreatment(new Key(null, null), string.Empty);
+
+            // Assert
+            Assert.AreEqual("control", result);
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void Track_ShouldReturnFalse_WithNullKey()
+        {
+            // Act
+            var result = _splitClientForTesting.Track(null, string.Empty, string.Empty);
+
+            // Assert
+            Assert.IsFalse(result);
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void Track_ShouldReturnFalse_WithNullTrafficType()
+        {
+            // Act
+            var result = _splitClientForTesting.Track(string.Empty, null, string.Empty);
+
+            // Assert
+            Assert.IsFalse(result);
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void Track_ShouldReturnFalse_WithNullEventType()
+        {
+            // Act
+            var result = _splitClientForTesting.Track(string.Empty, string.Empty, null);
+
+            // Assert
+            Assert.IsFalse(result);
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/Splitio-net-core-tests/Unit Tests/Client/SplitManagerUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitManagerUnitTests.cs
@@ -294,6 +294,20 @@ namespace Splitio_Tests.Unit_Tests.Client
         }
 
         [TestMethod]
+        public void SplitWithNullNameShouldReturnNull()
+        {
+            //Arrange
+            var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
+            var manager = new SplitManager(splitCache);
+
+            //Act
+            var result = manager.Split(null);
+
+            //Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
         public void SplitNamessWhenCacheIsEmptyShouldReturnEmptyList()
         {
             //Arrange

--- a/Splitio-net-core.Redis/Services/Client/Classes/RedisClient.cs
+++ b/Splitio-net-core.Redis/Services/Client/Classes/RedisClient.cs
@@ -37,7 +37,7 @@ namespace Splitio.Redis.Services.Client.Classes
         private static string RedisUserPrefix;
 
 
-        public RedisClient(ConfigurationOptions config)
+        public RedisClient(ConfigurationOptions config, ILog log) : base(log)
         {
             ReadConfig(config);
             BuildRedisCache();
@@ -61,7 +61,7 @@ namespace Splitio.Redis.Services.Client.Classes
             catch (Exception e)
             {
                 SdkMachineName = "unknown";
-                Log.Warn("Exception retrieving machine name.", e);
+                _log.Warn("Exception retrieving machine name.", e);
             }
 
             try
@@ -73,7 +73,7 @@ namespace Splitio.Redis.Services.Client.Classes
             catch (Exception e)
             {
                 SdkMachineIP = "unknown";
-                Log.Warn("Exception retrieving machine IP.", e);
+                _log.Warn("Exception retrieving machine IP.", e);
             }
 
             RedisHost = config.CacheAdapterConfig.Host;
@@ -153,7 +153,7 @@ namespace Splitio.Redis.Services.Client.Classes
                         RecordStats(key, feature, null, LabelSplitNotFound, start, Control, SdkGetTreatment, clock);
                     }
 
-                    Log.Warn(string.Format("Unknown or invalid feature: {0}", feature));
+                    _log.Warn(string.Format("Unknown or invalid feature: {0}", feature));
                     return Control;
                 }
 
@@ -168,7 +168,7 @@ namespace Splitio.Redis.Services.Client.Classes
                 //if there was an exception, impression label = "exception"
                 RecordStats(key, feature, null, LabelException, start, Control, SdkGetTreatment, clock);
 
-                Log.Error(string.Format("Exception caught getting treatment for feature: {0}", feature), e);
+                _log.Error(string.Format("Exception caught getting treatment for feature: {0}", feature), e);
                 return Control;
             }
         }

--- a/Splitio.TestSupport/Samples/SampleTest.cs
+++ b/Splitio.TestSupport/Samples/SampleTest.cs
@@ -1,4 +1,6 @@
-﻿using Splitio.Services.Client.Classes;
+﻿using Common.Logging;
+using Moq;
+using Splitio.Services.Client.Classes;
 using Xunit;
 
 namespace Splitio.TestSupport.Samples
@@ -6,13 +8,14 @@ namespace Splitio.TestSupport.Samples
     public class SampleTest
     {
         private SplitClientForTest splitClient;
+        private Mock<ILog> _logMock = new Mock<ILog>();
 
         [Theory]
         [SplitTest(test: @"{ feature:'feature_reads', treatments:['on', 'dark', 'off'] }")]
         public void SampleTest1(string feature, string treatment)
         {
             //Arrange
-            splitClient = new SplitClientForTest();
+            splitClient = new SplitClientForTest(_logMock.Object);
             splitClient.RegisterTreatment(feature, treatment);
 
             //Act
@@ -31,7 +34,7 @@ namespace Splitio.TestSupport.Samples
         public void SampleTest2(string feature, string treatment)
         {
             //Arrange
-            splitClient = new SplitClientForTest();
+            splitClient = new SplitClientForTest(_logMock.Object);
             splitClient.RegisterTreatment(feature, treatment);
 
             //Act
@@ -55,7 +58,7 @@ namespace Splitio.TestSupport.Samples
         public void SampleTest3(string feature, string treatment)
         {
             //Arrange
-            splitClient = new SplitClientForTest();
+            splitClient = new SplitClientForTest(_logMock.Object);
             splitClient.RegisterTreatment(feature, treatment);
 
             //Act

--- a/Splitio.TestSupport/SplitClientForTest.cs
+++ b/Splitio.TestSupport/SplitClientForTest.cs
@@ -1,4 +1,5 @@
-﻿using Splitio.Domain;
+﻿using Common.Logging;
+using Splitio.Domain;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,7 +9,7 @@ namespace Splitio.Services.Client.Classes
     {
         private Dictionary<string, string> _tests;
 
-        public SplitClientForTest()
+        public SplitClientForTest(ILog log) : base(log)
         {
             _tests = new Dictionary<string, string>();
         }

--- a/Splitio.TestSupport/Splitio-net-core.TestSupport.csproj
+++ b/Splitio.TestSupport/Splitio-net-core.TestSupport.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />

--- a/src/Splitio-net-core/Services/Client/Classes/JSONFileClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/JSONFileClient.cs
@@ -16,7 +16,7 @@ namespace Splitio.Services.Client.Classes
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(JSONFileClient));
 
-        public JSONFileClient(string splitsFilePath, string segmentsFilePath, ISegmentCache segmentCacheInstance = null, ISplitCache splitCacheInstance = null, IListener<KeyImpression> treatmentLogInstance = null, bool isLabelsEnabled = true)
+        public JSONFileClient(string splitsFilePath, string segmentsFilePath, ILog log, ISegmentCache segmentCacheInstance = null, ISplitCache splitCacheInstance = null, IListener<KeyImpression> treatmentLogInstance = null, bool isLabelsEnabled = true) : base(log)
         {
             segmentCache = segmentCacheInstance ?? new InMemorySegmentCache(new ConcurrentDictionary<string, Segment>());
             var segmentFetcher = new JSONFileSegmentFetcher(segmentsFilePath, segmentCache);

--- a/src/Splitio-net-core/Services/Client/Classes/LocalhostClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/LocalhostClient.cs
@@ -16,7 +16,7 @@ namespace Splitio.Services.Client.Classes
         private FileSystemWatcher watcher;
         private string fullPath;
 
-        public LocalhostClient(string filePath, Splitter splitter = null)
+        public LocalhostClient(string filePath, ILog log, Splitter splitter = null) : base(log)
         {
             fullPath = LookupFilePath(filePath);
             var directoryPath = Path.GetDirectoryName(fullPath);

--- a/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
@@ -71,7 +71,7 @@ namespace Splitio.Services.Client.Classes
         private IListener<KeyImpression> treatmentLog;
         private IListener<Event> eventLog;
 
-        public SelfRefreshingClient(string apiKey, ConfigurationOptions config)
+        public SelfRefreshingClient(string apiKey, ConfigurationOptions config, ILog log) : base(log)
         {
             ApiKey = apiKey;
             ReadConfig(config);
@@ -109,7 +109,7 @@ namespace Splitio.Services.Client.Classes
             catch(Exception e)
             {
                 SdkMachineName = "unknown";
-                Log.Warn("Exception retrieving machine name.", e);
+                _log.Warn("Exception retrieving machine name.", e);
             }
 
             try
@@ -121,7 +121,7 @@ namespace Splitio.Services.Client.Classes
             catch(Exception e)
             {
                 SdkMachineIP = "unknown";
-                Log.Warn("Exception retrieving machine IP.", e);
+                _log.Warn("Exception retrieving machine IP.", e);
             }
 
             RandomizeRefreshRates = config.RandomizeRefreshRates;

--- a/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace Splitio.Services.Client.Classes
 {
-    public abstract class SplitClient: ISplitClient
+    public abstract class SplitClient : ISplitClient
     {
         protected static readonly ILog Log = LogManager.GetLogger(typeof(SplitClient));
         protected const string Control = "control";
@@ -47,13 +47,33 @@ namespace Splitio.Services.Client.Classes
 
         public string GetTreatment(string key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false)
         {
-            Key keys = new Key(key, null);
-            return GetTreatment(keys, feature, attributes, logMetricsAndImpressions, multiple);
+            if (string.IsNullOrEmpty(key))
+            {
+                return LogErrorAndReturn($"{nameof(GetTreatment)}: key cannot be null");
+            }
+
+            return DoGetTreatment(new Key(key, null), feature, attributes, logMetricsAndImpressions, multiple);
         }
 
         public string GetTreatment(Key key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false)
         {
-            string featureHash = string.Concat(key.matchingKey, "#", feature, "#", attributes != null ? attributes.GetHashCode() : 0);
+            if (string.IsNullOrEmpty(key.matchingKey) || string.IsNullOrEmpty(key.bucketingKey))
+            {
+                return LogErrorAndReturn($"{nameof(GetTreatment)}: Key should be an object with bucketingKey and matchingKey with valid string properties.   ");
+            }
+
+            return DoGetTreatment(key, feature, attributes, logMetricsAndImpressions, multiple);
+        }
+
+        private string DoGetTreatment(Key key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false)
+        {
+            // TODO: once we decide if empty string is ok or not, create unit tests
+            if (string.IsNullOrEmpty(feature))
+            {
+                return LogErrorAndReturn($"{nameof(GetTreatment)}: split_name cannot be null");
+            }
+
+            var featureHash = string.Concat(key.matchingKey, "#", feature, "#", attributes != null ? attributes.GetHashCode() : 0);
 
             if (multiple && treatmentCache.ContainsKey(featureHash))
             {
@@ -70,6 +90,12 @@ namespace Splitio.Services.Client.Classes
             return result;
         }
 
+        private string LogErrorAndReturn(string errorMessage)
+        {
+            Log.Error(errorMessage);
+            return Control;
+        }
+
         protected void RecordStats(Key key, string feature, long? changeNumber, string label, long start, string treatment, string operation, Stopwatch clock)
         {
             if (metricsLog != null)
@@ -79,19 +105,19 @@ namespace Splitio.Services.Client.Classes
 
             if (impressionListener != null)
             {
-                KeyImpression impression = BuildImpression(key.matchingKey, feature, treatment, start, changeNumber, LabelsEnabled ? label : null, key.bucketingKeyHadValue ? key.bucketingKey : null);
+                var impression = BuildImpression(key.matchingKey, feature, treatment, start, changeNumber, LabelsEnabled ? label : null, key.bucketingKeyHadValue ? key.bucketingKey : null);
                 impressionListener.Log(impression);
             }
         }
 
         private KeyImpression BuildImpression(string matchingKey, string feature, string treatment, long time, long? changeNumber, string label, string bucketingKey)
         {
-            return new KeyImpression() { feature = feature, keyName = matchingKey, treatment = treatment, time = time, changeNumber = changeNumber, label = label, bucketingKey = bucketingKey };
+            return new KeyImpression { feature = feature, keyName = matchingKey, treatment = treatment, time = time, changeNumber = changeNumber, label = label, bucketingKey = bucketingKey };
         }
 
         protected virtual string GetTreatmentForFeature(Key key, string feature, Dictionary<string, object> attributes, bool logMetricsAndImpressions = true)
         {
-            long start = CurrentTimeHelper.CurrentTimeMillis();
+            var start = CurrentTimeHelper.CurrentTimeMillis();
             var clock = new Stopwatch();
             clock.Start();
 
@@ -107,8 +133,8 @@ namespace Splitio.Services.Client.Classes
                         RecordStats(key, feature, null, LabelSplitNotFound, start, Control, SdkGetTreatment, clock);
                     }
 
-                    Log.Warn(string.Format("Unknown or invalid feature: {0}", feature));
-                    
+                    Log.Warn($"Unknown or invalid feature: {feature}");
+
                     return Control;
                 }
 
@@ -124,7 +150,7 @@ namespace Splitio.Services.Client.Classes
                     RecordStats(key, feature, null, LabelException, start, Control, SdkGetTreatment, clock);
                 }
 
-                Log.Error(string.Format("Exception caught getting treatment for feature: {0}", feature), e);
+                Log.Error($"Exception caught getting treatment for feature: {feature}", e);
                 return Control;
             }
         }
@@ -135,14 +161,14 @@ namespace Splitio.Services.Client.Classes
             {
                 bool inRollout = false;
                 // use the first matching condition
-                foreach (ConditionWithLogic condition in split.conditions)
+                foreach (var condition in split.conditions)
                 {
                     if (!inRollout && condition.conditionType == ConditionType.ROLLOUT)
                     {
                         if (split.trafficAllocation < 100)
                         {
                             // bucket ranges from 1-100.
-                            int bucket = split.algo == AlgorithmEnum.LegacyHash ? splitter.LegacyBucket(key.bucketingKey, split.trafficAllocationSeed) : splitter.Bucket(key.bucketingKey, split.trafficAllocationSeed);
+                            var bucket = split.algo == AlgorithmEnum.LegacyHash ? splitter.LegacyBucket(key.bucketingKey, split.trafficAllocationSeed) : splitter.Bucket(key.bucketingKey, split.trafficAllocationSeed);
                             if (bucket >= split.trafficAllocation)
                             {
                                 if (logMetricsAndImpressions)
@@ -157,6 +183,7 @@ namespace Splitio.Services.Client.Classes
                         }
                         inRollout = true;
                     }
+
                     var combiningMatcher = condition.matcher;
                     if (combiningMatcher.Match(key, attributes, splitClient))
                     {
@@ -177,6 +204,7 @@ namespace Splitio.Services.Client.Classes
                     //If no condition matched, impression label = "default rule"
                     RecordStats(key, split.name, split.changeNumber, LabelDefaultRule, start, split.defaultTreatment, SdkGetTreatment, clock);
                 }
+
                 return split.defaultTreatment;
             }
             else
@@ -193,15 +221,15 @@ namespace Splitio.Services.Client.Classes
 
         public Dictionary<string, string> GetTreatments(string key, List<string> features, Dictionary<string, object> attributes = null)
         {
-            Key keys = new Key(key, null);
+            var keys = new Key(key, null);
             return GetTreatments(keys, features, attributes);
         }
 
         public Dictionary<string, string> GetTreatments(Key key, List<string> features, Dictionary<string, object> attributes = null)
         {
-            Dictionary<string, string> treatmentsForFeatures = new Dictionary<string, string>();
+            var treatmentsForFeatures = new Dictionary<string, string>();
 
-            foreach (string feature in features)
+            foreach (var feature in features)
             {
                 treatmentsForFeatures.Add(feature, GetTreatment(key, feature, attributes, true, true));
             }
@@ -215,7 +243,25 @@ namespace Splitio.Services.Client.Classes
         public virtual bool Track(string key, string trafficType, string eventType, double? value = null)
         {
             try
-            { 
+            {
+                if (string.IsNullOrEmpty(key))
+                {
+                    Log.Error($"{nameof(Track)}: {nameof(key)} cannot be null");
+                    return false;
+                }
+
+                if (string.IsNullOrEmpty(trafficType))
+                {
+                    Log.Error($"{nameof(Track)}: {nameof(trafficType)} cannot be null");
+                    return false;
+                }
+
+                if (string.IsNullOrEmpty(eventType))
+                {
+                    Log.Error($"{nameof(Track)}: {nameof(eventType)} cannot be null");
+                    return false;
+                }
+
                 eventListener.Log(new Event
                 {
                     key = key,
@@ -239,8 +285,7 @@ namespace Splitio.Services.Client.Classes
             var temporaryTreatmentCache = new ConcurrentDictionary<string, string>(treatmentCache);
             foreach (var item in temporaryTreatmentCache.Keys.Where(x => x.StartsWith(key)))
             {
-                string result;
-                temporaryTreatmentCache.TryRemove(item, out result);
+                temporaryTreatmentCache.TryRemove(item, out string result);
             }
             treatmentCache = temporaryTreatmentCache;
         }

--- a/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
@@ -72,7 +72,6 @@ namespace Splitio.Services.Client.Classes
 
         private string DoGetTreatment(Key key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false)
         {
-            // TODO: once we decide if empty string is ok or not, create unit tests
             if (feature == null)
             {
                 return LogErrorAndReturn($"{nameof(GetTreatment)}: split_name cannot be null");

--- a/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
@@ -16,7 +16,7 @@ namespace Splitio.Services.Client.Classes
 {
     public abstract class SplitClient : ISplitClient
     {
-        protected static readonly ILog Log = LogManager.GetLogger(typeof(SplitClient));
+        protected readonly ILog _log;
         protected const string Control = "control";
         protected const string SdkGetTreatment = "sdk.getTreatment";
         protected const string LabelKilled = "killed";
@@ -40,6 +40,11 @@ namespace Splitio.Services.Client.Classes
 
         private ConcurrentDictionary<string, string> treatmentCache = new ConcurrentDictionary<string, string>();
 
+        public SplitClient(ILog log)
+        {
+            _log = log;
+        }
+
         public ISplitManager GetSplitManager()
         {
             return manager;
@@ -47,7 +52,7 @@ namespace Splitio.Services.Client.Classes
 
         public string GetTreatment(string key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false)
         {
-            if (string.IsNullOrEmpty(key))
+            if (key == null)
             {
                 return LogErrorAndReturn($"{nameof(GetTreatment)}: key cannot be null");
             }
@@ -57,9 +62,9 @@ namespace Splitio.Services.Client.Classes
 
         public string GetTreatment(Key key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false)
         {
-            if (string.IsNullOrEmpty(key.matchingKey) || string.IsNullOrEmpty(key.bucketingKey))
+            if (key.matchingKey == null || key.bucketingKey == null)
             {
-                return LogErrorAndReturn($"{nameof(GetTreatment)}: Key should be an object with bucketingKey and matchingKey with valid string properties.   ");
+                return LogErrorAndReturn($"{nameof(GetTreatment)}: Key should be an object with bucketingKey and matchingKey with valid string properties.");
             }
 
             return DoGetTreatment(key, feature, attributes, logMetricsAndImpressions, multiple);
@@ -68,7 +73,7 @@ namespace Splitio.Services.Client.Classes
         private string DoGetTreatment(Key key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false)
         {
             // TODO: once we decide if empty string is ok or not, create unit tests
-            if (string.IsNullOrEmpty(feature))
+            if (feature == null)
             {
                 return LogErrorAndReturn($"{nameof(GetTreatment)}: split_name cannot be null");
             }
@@ -92,7 +97,7 @@ namespace Splitio.Services.Client.Classes
 
         private string LogErrorAndReturn(string errorMessage)
         {
-            Log.Error(errorMessage);
+            _log.Error(errorMessage);
             return Control;
         }
 
@@ -133,7 +138,7 @@ namespace Splitio.Services.Client.Classes
                         RecordStats(key, feature, null, LabelSplitNotFound, start, Control, SdkGetTreatment, clock);
                     }
 
-                    Log.Warn($"Unknown or invalid feature: {feature}");
+                    _log.Warn($"Unknown or invalid feature: {feature}");
 
                     return Control;
                 }
@@ -150,7 +155,7 @@ namespace Splitio.Services.Client.Classes
                     RecordStats(key, feature, null, LabelException, start, Control, SdkGetTreatment, clock);
                 }
 
-                Log.Error($"Exception caught getting treatment for feature: {feature}", e);
+                _log.Error($"Exception caught getting treatment for feature: {feature}", e);
                 return Control;
             }
         }
@@ -244,21 +249,21 @@ namespace Splitio.Services.Client.Classes
         {
             try
             {
-                if (string.IsNullOrEmpty(key))
+                if (key == null)
                 {
-                    Log.Error($"{nameof(Track)}: {nameof(key)} cannot be null");
+                    _log.Error($"{nameof(Track)}: {nameof(key)} cannot be null");
                     return false;
                 }
 
-                if (string.IsNullOrEmpty(trafficType))
+                if (trafficType == null)
                 {
-                    Log.Error($"{nameof(Track)}: {nameof(trafficType)} cannot be null");
+                    _log.Error($"{nameof(Track)}: {nameof(trafficType)} cannot be null");
                     return false;
                 }
 
-                if (string.IsNullOrEmpty(eventType))
+                if (eventType == null)
                 {
-                    Log.Error($"{nameof(Track)}: {nameof(eventType)} cannot be null");
+                    _log.Error($"{nameof(Track)}: {nameof(eventType)} cannot be null");
                     return false;
                 }
 
@@ -275,7 +280,7 @@ namespace Splitio.Services.Client.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception caught trying to track an event", e);
+                _log.Error("Exception caught trying to track an event", e);
                 return false;
             }
         }

--- a/src/Splitio-net-core/Services/Client/Classes/SplitFactory.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitFactory.cs
@@ -44,11 +44,11 @@ namespace Splitio.Services.Client.Classes
                     }
                     if (apiKey == "localhost")
                     {
-                        client = new LocalhostClient(options.LocalhostFilePath);
+                        client = new LocalhostClient(options.LocalhostFilePath, Common.Logging.LogManager.GetLogger(typeof(SplitClient)));
                     }
                     else
                     {
-                        client = new SelfRefreshingClient(apiKey, options);
+                        client = new SelfRefreshingClient(apiKey, options, Common.Logging.LogManager.GetLogger(typeof(SplitClient)));
                     }
                     break;
                 case Mode.Consumer:

--- a/src/Splitio-net-core/Services/Client/Classes/SplitFactory.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitFactory.cs
@@ -62,7 +62,7 @@ namespace Splitio.Services.Client.Classes
                             }
                             var redisAssembly = Assembly.Load(new AssemblyName("Splitio-net-core.Redis"));
                             var redisType = redisAssembly.GetType("Splitio.Redis.Services.Client.Classes.RedisClient");
-                            client = (ISplitClient)Activator.CreateInstance(redisType, new Object[] { options });
+                            client = (ISplitClient)Activator.CreateInstance(redisType, new Object[] { options, Common.Logging.LogManager.GetLogger(typeof(SplitClient)) });
 
                         }
                         catch (Exception e)

--- a/src/Splitio-net-core/Services/Client/Classes/SplitManager.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitManager.cs
@@ -1,4 +1,5 @@
-﻿using Splitio.Domain;
+﻿using Common.Logging;
+using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Client.Interfaces;
 using System.Collections.Generic;
@@ -8,7 +9,8 @@ namespace Splitio.Services.Client.Classes
 {
     public class SplitManager : ISplitManager
     {
-        ISplitCache splitCache;
+        protected static readonly ILog Log = LogManager.GetLogger(typeof(SplitManager));
+        private readonly ISplitCache splitCache;
 
         public SplitManager(ISplitCache splitCache)
         {
@@ -40,6 +42,12 @@ namespace Splitio.Services.Client.Classes
 
         public SplitView Split(string featureName)
         {
+            if (string.IsNullOrEmpty(featureName))
+            {
+                Log.Error($"{nameof(Split)}: {nameof(featureName)} cannot be null");
+                return null;
+            }
+
             if (splitCache == null)
             {
                 return null;

--- a/src/Splitio-net-core/Services/Client/Classes/SplitManager.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitManager.cs
@@ -42,7 +42,7 @@ namespace Splitio.Services.Client.Classes
 
         public SplitView Split(string featureName)
         {
-            if (string.IsNullOrEmpty(featureName))
+            if (featureName == null)
             {
                 Log.Error($"{nameof(Split)}: {nameof(featureName)} cannot be null");
                 return null;


### PR DESCRIPTION
# Background
We need to validate that some of the parameters sent to our methods are not null

# Changes done
- Validate required parameters
- Fix broken tests
- Change `SplitClient` (and derived classes) to get an `ILog` instance injected so testing is easier (it was being constructed inside the client)
- Create new Unit Tests

# Pending to be done
- [x] Decide if ERROR is the right level to log
- [x] Decide if validations should be performed for the localhost version of `Track`
- [x] Check question related to bucketingKey and matchingKey being null
- [ ] Confirm `string.empty` is a valid value