### PR TITLE
Implement BUR for RedisClient

### DIFF
--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisAdapter.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisAdapter.cs
@@ -14,7 +14,7 @@ namespace Splitio.Redis.Services.Cache.Classes
         private IDatabase database;
         private IServer server;
 
-        public RedisAdapter(string host, string port, string password = "", int databaseNumber = 0, 
+        public RedisAdapter(string host, string port, string password = "", int databaseNumber = 0,
             int connectTimeout = 0, int connectRetry = 0, int syncTimeout = 0)
         {
             try
@@ -30,20 +30,25 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
         }
 
+        public bool IsConnected()
+        {
+            return server?.IsConnected ?? false;
+        }
+
         private static string GetConfig(string host, string port, string password, int connectTimeout, int connectRetry, int syncTimeout)
         {
             var config = string.Format("{0}:{1}, password = {2}, allowAdmin = true", host, port, password);
-            
+
             if (connectTimeout > 0)
             {
                 config += ", connectTimeout = " + connectTimeout;
             }
-            
+
             if (connectRetry > 0)
             {
                 config += ", connectRetry = " + connectRetry;
             }
-            
+
             if (syncTimeout > 0)
             {
                 config += ", syncTimeout = " + syncTimeout;

--- a/Splitio-net-core.Redis/Services/Cache/Interfaces/IRedisAdapter.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Interfaces/IRedisAdapter.cs
@@ -31,5 +31,7 @@ namespace Splitio.Redis.Services.Cache.Interfaces
         long IcrBy(string key, long delta);
 
         void Flush();
+
+        bool IsConnected();
     }
 }

--- a/Splitio-net-core.Redis/Services/Client/Classes/RedisClient.cs
+++ b/Splitio-net-core.Redis/Services/Client/Classes/RedisClient.cs
@@ -93,7 +93,7 @@ namespace Splitio.Redis.Services.Client.Classes
             redisAdapter = new RedisAdapter(RedisHost, RedisPort, RedisPassword, RedisDatabase, RedisConnectTimeout, RedisConnectRetry, RedisSyncTimeout);
             if (BlockMilisecondsUntilReady > 0 && !redisAdapter.IsConnected())
             {
-                throw new TimeoutException($"SDK was not ready in {BlockMilisecondsUntilReady} miliseconds");
+                throw new TimeoutException($"SDK was not ready in {BlockMilisecondsUntilReady} miliseconds. Could not connect to Redis");
             }
 
             splitCache = new RedisSplitCache(redisAdapter, RedisUserPrefix);


### PR DESCRIPTION
Throw `TimeoutException` if SDK is in Consumer mode, `Ready` is greater than 0 and can't connect to Redis
