### PR TITLE
[SDKS-624][PART 1] Store dynamic configs on splitChanges 

### DIFF
--- a/src/Splitio-net-core/Domain/Split.cs
+++ b/src/Splitio-net-core/Domain/Split.cs
@@ -15,5 +15,6 @@ namespace Splitio.Domain
         public int? algo { get; set; }
         public int trafficAllocation { get; set; }
         public int? trafficAllocationSeed { get; set; }
+        public object configurations { get; set; }
     }
 }


### PR DESCRIPTION
## Background
I am working on the ticket [[SDKS-624][NET CORE]: Implement treatmentWithConfig and treatmentsWithConfig.
](https://splitio.atlassian.net/browse/SDKS-624)
I will split this in 4 PRs:
### 1 - Store dynamic configs on splitChanges 
2 - Update Evaluator Result to return dynamic config
3 - Implement treatmentWithConfig and treatmentsWithConfig.
4 - Update SplitView for manager to return dynamic configs

## Changes

- Added Split.Configurations property to map it from BE.
- Fixed and added tests.

[SDKS-624]: https://splitio.atlassian.net/browse/SDKS-624