### PR TITLE
[SDKS-624][PART 3] treatmentWithConfig and treatmentsWithConfig implementation

### DIFF
--- a/Splitio-net-core-tests/Integration Tests/SelfRefreshingSplitClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/SelfRefreshingSplitClientTests.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Splitio.Domain;
 using Splitio.Services.Client.Classes;
+using Splitio.Services.Client.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Splitio_Tests.Integration_Tests
@@ -9,24 +12,90 @@ namespace Splitio_Tests.Integration_Tests
     public class SelfRefreshingSplitClientTests
     {
         [TestMethod]
-        public void DestroySuccessfully()
+        public void GetTreatmentWithConfig_ReturnsSplitResult()
         {
-            //Arrange
-            var apikey = "API_KEY";
+            //Act
+            var client = GetClientInstance();
+            var splitResult = client.GetTreatmentWithConfig("littlespoon", "always_on");
 
-            var configurations = new ConfigurationOptions();
-            configurations.Ready = 60000;
-            configurations.FeaturesRefreshRate = 30;
-            configurations.SegmentsRefreshRate = 30;
-            configurations.Endpoint = "https://sdk-aws-staging.split.io";
-            configurations.EventsEndpoint = "https://events-aws-staging.split.io";
-            configurations.ReadTimeout = 20000;
-            configurations.ConnectionTimeout = 20000;
+            //Assert
+            Assert.AreEqual("on", splitResult.Treatment);
+            Assert.IsNotNull(splitResult.Config);
+        }
 
-            var factory = new SplitFactory(apikey, configurations);
-            var client = factory.Client();
+        [TestMethod]
+        public void GetTreatmentWithConfig_WithKeyObject_ReturnsSplitResult()
+        {
+            //Arange
+            var key = new Key("littlespoon", null);
 
             //Act
+            var client = GetClientInstance();
+            var splitResult = client.GetTreatmentWithConfig(key, "always_on");
+
+            //Assert
+            Assert.AreEqual("on", splitResult.Treatment);
+            Assert.IsNotNull(splitResult.Config);
+        }
+
+        [TestMethod]
+        public void GetTreatmentsWithConfig_ReturnsSplitResult()
+        {
+            //Arange
+            var features = new List<string> { "always_on", "always_off" };
+
+            //Act
+            var client = GetClientInstance();
+            var splitResults = client.GetTreatmentsWithConfig("littlespoon", features);
+
+            //Assert
+            foreach (var result in splitResults)
+            {
+                if (result.Key.Equals("always_on"))
+                {
+                    Assert.AreEqual("on", result.Value.Treatment);
+                    Assert.IsNotNull(result.Value.Config);
+                }
+                else
+                {
+                    Assert.AreEqual("off", result.Value.Treatment);
+                    Assert.IsNotNull(result.Value.Config);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void GetTreatmentsWithConfig_WithKeyObject_ReturnsSplitResult()
+        {
+            //Arange
+            var key = new Key("littlespoon", null);
+            var features = new List<string> { "always_on", "always_off" };
+
+            //Act
+            var client = GetClientInstance();
+            var splitResults = client.GetTreatmentsWithConfig(key, features);
+
+            //Assert
+            foreach (var result in splitResults)
+            {
+                if (result.Key.Equals("always_on"))
+                {
+                    Assert.AreEqual("on", result.Value.Treatment);
+                    Assert.IsNotNull(result.Value.Config);
+                }
+                else
+                {
+                    Assert.AreEqual("off", result.Value.Treatment);
+                    Assert.IsNotNull(result.Value.Config);
+                }
+            }
+        }
+                
+        [TestMethod]
+        public void DestroySuccessfully()
+        {
+            //Act
+            var client = GetClientInstance();
             var result1 = client.GetTreatment("littlespoon", "always_on");
 
             client.Destroy();
@@ -43,6 +112,23 @@ namespace Splitio_Tests.Integration_Tests
             Assert.IsFalse(resultDestroy2.Any());
             Assert.IsFalse(resultDestroy3.Any());
             Assert.IsNull(resultDestroy4);
+        }
+
+        private ISplitClient GetClientInstance()
+        {
+            var apikey = "API_KEY";
+
+            var configurations = new ConfigurationOptions();
+            configurations.Ready = 60000;
+            configurations.FeaturesRefreshRate = 30;
+            configurations.SegmentsRefreshRate = 30;
+            configurations.Endpoint = "https://sdk.split-stage.io";
+            configurations.EventsEndpoint = "https://events.split-stage.io";
+            configurations.ReadTimeout = 20000;
+            configurations.ConnectionTimeout = 20000;
+
+            var factory = new SplitFactory(apikey, configurations);
+            return factory.Client();
         }
     }
 }

--- a/Splitio-net-core-tests/Unit Tests/Client/SplitClientUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitClientUnitTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
+using System.Collections.Generic;
 
 namespace Splitio_Tests.Unit_Tests.Client
 {
@@ -18,6 +19,7 @@ namespace Splitio_Tests.Unit_Tests.Client
             _splitClientForTesting = new SplitClientForTesting(_logMock.Object);
         }
 
+        #region GetTreatment
         [TestMethod]
         public void GetTreatment_ShouldReturnControl_WithNullKey()
         {
@@ -50,7 +52,69 @@ namespace Splitio_Tests.Unit_Tests.Client
             Assert.AreEqual("control", result);
             _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
         }
+        #endregion
 
+        #region GetTreatmentWithConfig
+        [TestMethod]
+        public void GetTreatmentWithConfig_WithEmptyKey_ShouldReturnControl()
+        {
+            // Act
+            var result = _splitClientForTesting.GetTreatmentWithConfig(string.Empty, string.Empty);
+
+            // Assert
+            Assert.AreEqual("control", result.Treatment);
+            Assert.IsNull(result.Config);
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
+        }
+
+        [TestMethod]
+        public void GetTreatmentWithConfig_WithNullKey_ShouldReturnControl()
+        {
+            // Act
+            var result = _splitClientForTesting.GetTreatmentWithConfig((Key)null, string.Empty);
+
+            // Assert
+            Assert.AreEqual("control", result.Treatment);
+            Assert.IsNull(result.Config);
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
+        }
+        #endregion
+
+        #region GetTreatmentsWithConfig
+        [TestMethod]
+        public void GetTreatmentsWithConfig_WithEmptyKey_ShouldReturnControl()
+        {
+            // Act
+            var results = _splitClientForTesting.GetTreatmentsWithConfig(string.Empty, new List<string> { string.Empty });
+
+            // Assert
+            foreach (var res in results)
+            {
+                Assert.AreEqual("control", res.Value.Treatment);
+                Assert.IsNull(res.Value.Config);
+            }
+
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
+        }
+
+        [TestMethod]
+        public void GetTreatmentsWithConfig_WithNullKey_ShouldReturnControl()
+        {
+            // Act
+            var results = _splitClientForTesting.GetTreatmentsWithConfig((Key)null, new List<string> { string.Empty });
+
+            // Assert
+            foreach (var res in results)
+            {
+                Assert.AreEqual("control", res.Value.Treatment);
+                Assert.IsNull(res.Value.Config);
+            }
+
+            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
+        }
+        #endregion
+
+        #region Track
         [TestMethod]
         public void Track_ShouldReturnFalse_WithNullKey()
         {
@@ -83,5 +147,6 @@ namespace Splitio_Tests.Unit_Tests.Client
             Assert.IsFalse(result);
             _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(4));
         }
+        #endregion
     }
 }

--- a/src/Splitio-net-core/Domain/SplitResult.cs
+++ b/src/Splitio-net-core/Domain/SplitResult.cs
@@ -1,0 +1,8 @@
+﻿namespace Splitio.Domain
+{
+    public class SplitResult
+    {
+        public string Treatment { get; set; }
+        public object Config { get; set; }
+    }
+}

--- a/src/Splitio-net-core/Services/Client/Interfaces/ISplitClient.cs
+++ b/src/Splitio-net-core/Services/Client/Interfaces/ISplitClient.cs
@@ -6,19 +6,16 @@ namespace Splitio.Services.Client.Interfaces
     public interface ISplitClient
     {
         ISplitManager GetSplitManager();
-
         string GetTreatment(string key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false);
-
         string GetTreatment(Key key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false);
-
+        SplitResult GetTreatmentWithConfig(string key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false);
+        SplitResult GetTreatmentWithConfig(Key key, string feature, Dictionary<string, object> attributes = null, bool logMetricsAndImpressions = true, bool multiple = false);
         Dictionary<string, string> GetTreatments(string key, List<string> features, Dictionary<string, object> attributes = null);
-
         Dictionary<string, string> GetTreatments(Key key, List<string> features, Dictionary<string, object> attributes = null);
-
+        Dictionary<string, SplitResult> GetTreatmentsWithConfig(string key, List<string> features, Dictionary<string, object> attributes = null);
+        Dictionary<string, SplitResult> GetTreatmentsWithConfig(Key key, List<string> features, Dictionary<string, object> attributes = null);
         bool Track(string key, string trafficType, string eventType, double? value = null);
-
         void Destroy();
-
         bool IsDestroyed();
     }
 }

--- a/src/Splitio-net-core/Services/InputValidation/Classes/KeyValidator.cs
+++ b/src/Splitio-net-core/Services/InputValidation/Classes/KeyValidator.cs
@@ -17,8 +17,8 @@ namespace Splitio.Services.InputValidation.Classes
 
         public bool IsValid(Key key, string method)
         {
-            var matchingKeyIsValid = Validate(key.matchingKey, method, nameof(key.matchingKey));
-            var bucketingKeyIsValid = Validate(key.bucketingKey, method, nameof(key.bucketingKey));
+            var matchingKeyIsValid = Validate(key?.matchingKey, method, nameof(key.matchingKey));
+            var bucketingKeyIsValid = Validate(key?.bucketingKey, method, nameof(key.bucketingKey));
 
             return matchingKeyIsValid && bucketingKeyIsValid;
         }


### PR DESCRIPTION
## Background
I am working on the ticket [[SDKS-624][NET CORE]: Implement treatmentWithConfig and treatmentsWithConfig.
](https://splitio.atlassian.net/browse/SDKS-624)
I will split this in 4 PRs:

1 -  Store dynamic configs on splitChanges ✔
2 - Update Evaluator Result to return dynamic config ✔
### 3 - Implement treatmentWithConfig and treatmentsWithConfig.
4 - Update SplitView for manager to return dynamic configs

## Changes

- GetTreatmentWithConfig and GetTreatmentsWithConfig implementation

## Tests
Client simulator:

![image](https://user-images.githubusercontent.com/45955156/56251480-255b3b00-608a-11e9-8f75-606fd62b9606.png)



[SDKS-624]: https://splitio.atlassian.net/browse/SDKS-624