### PR TITLE
[SDKS-624][PART 4] Update SplitView for manager to return dynamic configs

### DIFF
--- a/Splitio-net-core-tests/Unit Tests/Client/SplitManagerUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitManagerUnitTests.cs
@@ -367,5 +367,83 @@ namespace Splitio_Tests.Unit_Tests.Client
             var firstResult = result.Find(x => x == "test1");
             Assert.AreEqual(firstResult, "test1");
         }
+
+        [TestMethod]
+        public void Splits_WithConfigs_ReturnSuccessfully()
+        {
+            //Arrange
+            var configurations = new { On = new { Name = "Test Config" } };
+            var conditionsWithLogic = new List<ConditionWithLogic>();
+            var conditionWithLogic = new ConditionWithLogic()
+            {
+                partitions = new List<PartitionDefinition>()
+                {
+                    new PartitionDefinition(){size = 100, treatment = "on"}
+                }
+            };
+            conditionsWithLogic.Add(conditionWithLogic);
+
+            var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
+            splitCache.AddSplit("test1", new ParsedSplit() { name = "test1", changeNumber = 10000, killed = false, trafficTypeName = "user", seed = -1, conditions = conditionsWithLogic, configurations = configurations });
+            splitCache.AddSplit("test2", new ParsedSplit() { name = "test2", conditions = conditionsWithLogic, configurations = configurations });
+            splitCache.AddSplit("test3", new ParsedSplit() { name = "test3", conditions = conditionsWithLogic });
+            splitCache.AddSplit("test4", new ParsedSplit() { name = "test4", conditions = conditionsWithLogic });
+            splitCache.AddSplit("test5", new ParsedSplit() { name = "test5", conditions = conditionsWithLogic });
+            splitCache.AddSplit("test6", new ParsedSplit() { name = "test6", conditions = conditionsWithLogic });
+
+            var manager = new SplitManager(splitCache);
+
+            //Act
+            var result = manager.Splits();
+
+            //Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(6, result.Count);
+            var test1Result = result.Find(res => res.name == "test1");
+            Assert.IsNotNull(test1Result.configs);
+            var test2Result = result.Find(res => res.name == "test2");
+            Assert.IsNotNull(test2Result.configs);
+            var test3Result = result.Find(res => res.name == "test3");
+            Assert.IsNull(test3Result.configs);
+        }
+
+        [TestMethod]
+        public void Split_WithConfigs_ReturnSuccessfully()
+        {
+            //Arrange
+            var configurations = new { On = new { Name = "Test Config" } };
+            var conditionsWithLogic = new List<ConditionWithLogic>();
+            var conditionWithLogic = new ConditionWithLogic()
+            {
+                partitions = new List<PartitionDefinition>()
+                {
+                    new PartitionDefinition(){size = 100, treatment = "on"}
+                }
+            };
+            conditionsWithLogic.Add(conditionWithLogic);
+
+            var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
+            splitCache.AddSplit("test1", new ParsedSplit() { name = "test1", changeNumber = 10000, killed = false, trafficTypeName = "user", seed = -1, conditions = conditionsWithLogic, configurations = configurations });
+            splitCache.AddSplit("test2", new ParsedSplit() { name = "test2", conditions = conditionsWithLogic, configurations = configurations });
+            splitCache.AddSplit("test3", new ParsedSplit() { name = "test3", conditions = conditionsWithLogic });
+            splitCache.AddSplit("test4", new ParsedSplit() { name = "test4", conditions = conditionsWithLogic });
+            splitCache.AddSplit("test5", new ParsedSplit() { name = "test5", conditions = conditionsWithLogic });
+            splitCache.AddSplit("test6", new ParsedSplit() { name = "test6", conditions = conditionsWithLogic });
+
+            var manager = new SplitManager(splitCache);
+
+            //Act
+            var result1 = manager.Split("test1");
+            var result2 = manager.Split("test2");
+            var result3 = manager.Split("test3");
+
+            //Assert
+            Assert.IsNotNull(result1);
+            Assert.IsNotNull(result1.configs);
+            Assert.IsNotNull(result2);
+            Assert.IsNotNull(result2.configs);
+            Assert.IsNotNull(result3);
+            Assert.IsNull(result3.configs);
+        }
     }
 }

--- a/src/Splitio-net-core/Domain/LightSplit.cs
+++ b/src/Splitio-net-core/Domain/LightSplit.cs
@@ -9,5 +9,6 @@ namespace Splitio.Domain
         public bool killed { get; set; }
         public List<string> treatments { get; set; }
         public long changeNumber { get; set; }
+        public object configs { get; set; }
     }
 }

--- a/src/Splitio-net-core/Services/Client/Classes/SplitManager.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitManager.cs
@@ -37,7 +37,8 @@ namespace Splitio.Services.Client.Classes
                     killed = x.killed,
                     changeNumber = x.changeNumber,
                     treatments = (x.conditions.Where(z => z.conditionType == ConditionType.ROLLOUT).FirstOrDefault() ?? new ConditionWithLogic() { partitions = new List<PartitionDefinition>() }).partitions.Select(y => y.treatment).ToList(),
-                    trafficType = x.trafficTypeName
+                    trafficType = x.trafficTypeName,
+                    configs = x.configurations
                 });
 
             return lightSplits.ToList();
@@ -72,7 +73,8 @@ namespace Splitio.Services.Client.Classes
                 killed = split.killed,
                 changeNumber = split.changeNumber,
                 treatments = treatments,
-                trafficType = split.trafficTypeName
+                trafficType = split.trafficTypeName,
+                configs = split.configurations
             };
 
             return lightSplit;


### PR DESCRIPTION
## Background
I am working on the ticket [[SDKS-624][NET CORE]: Implement treatmentWithConfig and treatmentsWithConfig.
](https://splitio.atlassian.net/browse/SDKS-624)
I will split this in 4 PRs:

1 -  Store dynamic configs on splitChanges ✔
2 - Update Evaluator Result to return dynamic config ✔
3 - Implement treatmentWithConfig and treatmentsWithConfig. ✔
### 4 - Update SplitView for manager to return dynamic configs

## Changes

- Updated SplitView for manager to return dynamic configs.

## Tests

![image](https://user-images.githubusercontent.com/45955156/56252638-0f9c4480-608f-11e9-93c5-3e8d896a5133.png)

[SDKS-624]: https://splitio.atlassian.net/browse/SDKS-624