### PR TITLE
[SDKS-710][Bugfix] SDK return error when posting events successfully

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+4.1.1
+- Bugfix: SDK return error when posting events successfully.
+
 4.1.0
 - Added Dynamic Configurations support through two new methods that mimick the regular ones, changing the type of what is returned.
   - GetTreatmentWithConfig: Same as getTreatment, but instead of a string it returns a map with treatment and config as a stringified JSON.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,8 @@
 NEWS
 
+4.1.1
+- Bugfix: SDK return error when posting events successfully.
+
 4.1.0
 - Added Dynamic Configurations support through two new methods that mimick the regular ones, changing the type of what is returned.
   - GetTreatmentWithConfig: Same as getTreatment, but instead of a string it returns a map with treatment and config as a stringified JSON.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 nuget:
   account_feed: true
 
-version: 4.1.0
+version: 4.1.1-rc{build}
 
 dotnet_csproj:
   patch: true

--- a/src/Splitio-net-core/Services/Events/Classes/EventSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Events/Classes/EventSdkApiClient.cs
@@ -27,7 +27,7 @@ namespace Splitio.Services.Events.Classes
 
             var response = await ExecutePost(EventsUrlTemplate, eventsJson);
 
-            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
+            if ((int)response.statusCode < (int)HttpStatusCode.OK || (int)response.statusCode >= (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendBulkEvents: {0} - {1}", response.statusCode.ToString(), response.content));
             }

--- a/src/Splitio-net-core/Services/Events/Classes/EventSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Events/Classes/EventSdkApiClient.cs
@@ -14,7 +14,9 @@ namespace Splitio.Services.Events.Classes
         
         private static readonly ILog Log = LogManager.GetLogger(typeof(EventSdkApiClient));
 
-        public EventSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
+        public EventSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) 
+            : base(header, baseUrl, connectionTimeOut, readTimeout)
+        { }
 
         public async void SendBulkEvents(List<Event> events)
         {
@@ -24,7 +26,8 @@ namespace Splitio.Services.Events.Classes
             });
 
             var response = await ExecutePost(EventsUrlTemplate, eventsJson);
-            if (response.statusCode != HttpStatusCode.OK)
+
+            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendBulkEvents: {0} - {1}", response.statusCode.ToString(), response.content));
             }

--- a/src/Splitio-net-core/Services/Impressions/Classes/TreatmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Impressions/Classes/TreatmentSdkApiClient.cs
@@ -15,14 +15,17 @@ namespace Splitio.Services.Impressions.Classes
         
         private static readonly ILog Log = LogManager.GetLogger(typeof(TreatmentSdkApiClient));
 
-        public TreatmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
+        public TreatmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) 
+            : base(header, baseUrl, connectionTimeOut, readTimeout)
+        { }
 
         public async void SendBulkImpressions(List<KeyImpression> impressions)
         {
             var impressionsJson = ConvertToJson(impressions);
 
             var response = await ExecutePost(TestImpressionsUrlTemplate, impressionsJson);
-            if (response.statusCode != HttpStatusCode.OK)
+
+            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendBulkImpressions: {0} - {1}", response.statusCode.ToString(), response.content));
             }

--- a/src/Splitio-net-core/Services/Impressions/Classes/TreatmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Impressions/Classes/TreatmentSdkApiClient.cs
@@ -25,7 +25,7 @@ namespace Splitio.Services.Impressions.Classes
 
             var response = await ExecutePost(TestImpressionsUrlTemplate, impressionsJson);
 
-            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
+            if ((int)response.statusCode < (int)HttpStatusCode.OK || (int)response.statusCode >= (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendBulkImpressions: {0} - {1}", response.statusCode.ToString(), response.content));
             }

--- a/src/Splitio-net-core/Services/Metrics/Classes/MetricsSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Metrics/Classes/MetricsSdkApiClient.cs
@@ -11,12 +11,15 @@ namespace Splitio.Services.Metrics.Classes
 
         private static readonly ILog Log = LogManager.GetLogger(typeof(MetricsSdkApiClient));
 
-        public MetricsSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
+        public MetricsSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) 
+            : base(header, baseUrl, connectionTimeOut, readTimeout)
+        { }
 
         public async void SendCountMetrics(string metrics)
         {
             var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "counters"), metrics);
-            if (response.statusCode != HttpStatusCode.OK)
+
+            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendCountMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }
@@ -25,7 +28,8 @@ namespace Splitio.Services.Metrics.Classes
         public async void SendTimeMetrics(string metrics)
         {
             var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "times"), metrics);
-            if (response.statusCode != HttpStatusCode.OK)
+
+            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendTimeMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }
@@ -34,7 +38,8 @@ namespace Splitio.Services.Metrics.Classes
         public async void SendGaugeMetrics(string metrics)
         {
             var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "gauge"), metrics);
-            if (response.statusCode != HttpStatusCode.OK)
+
+            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendGaugeMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }

--- a/src/Splitio-net-core/Services/Metrics/Classes/MetricsSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Metrics/Classes/MetricsSdkApiClient.cs
@@ -19,7 +19,7 @@ namespace Splitio.Services.Metrics.Classes
         {
             var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "counters"), metrics);
 
-            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
+            if ((int)response.statusCode < (int)HttpStatusCode.OK || (int)response.statusCode >= (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendCountMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }
@@ -29,7 +29,7 @@ namespace Splitio.Services.Metrics.Classes
         {
             var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "times"), metrics);
 
-            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
+            if ((int)response.statusCode < (int)HttpStatusCode.OK || (int)response.statusCode >= (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendTimeMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }
@@ -39,7 +39,7 @@ namespace Splitio.Services.Metrics.Classes
         {
             var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "gauge"), metrics);
 
-            if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
+            if ((int)response.statusCode < (int)HttpStatusCode.OK || (int)response.statusCode >= (int)HttpStatusCode.Ambiguous)
             {
                 Log.Error(string.Format("Http status executing SendGaugeMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -45,26 +45,18 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
                     return response.content;
                 }
-                else if (response.statusCode == HttpStatusCode.Forbidden)
-                {
-                    if (metricsLog != null)
-                    {
-                        metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
-                    }
-
-                    Log.Error("factory instantiation: you passed a browser type api_key, please grab an api key from the Split console that is of type sdk");
-
-                    return string.Empty;
-                }
 
                 if (metricsLog != null)
                 {
                     metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
                 }
 
-                Log.Error(string.Format("Http status executing FetchSegmentChanges: {0} - {1}", response.statusCode.ToString(), response.content));
+                Log.Error(response.statusCode == HttpStatusCode.Forbidden
+                    ? "factory instantiation: you passed a browser type api_key, please grab an api key from the Split console that is of type sdk"
+                    : string.Format("Http status executing FetchSegmentChanges: {0} - {1}", response.statusCode.ToString(), response.content));
 
                 return string.Empty;
+               
             }
             catch (Exception e)
             {

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -30,40 +30,41 @@ namespace Splitio.Services.SegmentFetcher.Classes
                 var requestUri = GetRequestUri(name, since);
                 var response = await ExecuteGet(requestUri);
 
-                switch (response.statusCode)
+                if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
                 {
-                    case HttpStatusCode.OK:
-                        if (metricsLog != null)
-                        {
-                            metricsLog.Time(SegmentFetcherTime, clock.ElapsedMilliseconds);
-                            metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
-                        }
+                    if (metricsLog != null)
+                    {
+                        metricsLog.Time(SegmentFetcherTime, clock.ElapsedMilliseconds);
+                        metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
+                    }
 
-                        if (Log.IsDebugEnabled)
-                        {
-                            Log.Debug($"FetchSegmentChanges with name '{name}' took {clock.ElapsedMilliseconds} milliseconds using uri '{requestUri}'");
-                        }
+                    if (Log.IsDebugEnabled)
+                    {
+                        Log.Debug($"FetchSegmentChanges with name '{name}' took {clock.ElapsedMilliseconds} milliseconds using uri '{requestUri}'");
+                    }
 
-                        return response.content;
-                    case HttpStatusCode.Forbidden:
-                        if (metricsLog != null)
-                        {
-                            metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
-                        }
-
-                        Log.Error("factory instantiation: you passed a browser type api_key, please grab an api key from the Split console that is of type sdk");
-
-                        return string.Empty;
-                    default:
-                        if (metricsLog != null)
-                        {
-                            metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
-                        }
-
-                        Log.Error(string.Format("Http status executing FetchSegmentChanges: {0} - {1}", response.statusCode.ToString(), response.content));
-
-                        return string.Empty;
+                    return response.content;
                 }
+                else if (response.statusCode == HttpStatusCode.Forbidden)
+                {
+                    if (metricsLog != null)
+                    {
+                        metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
+                    }
+
+                    Log.Error("factory instantiation: you passed a browser type api_key, please grab an api key from the Split console that is of type sdk");
+
+                    return string.Empty;
+                }
+
+                if (metricsLog != null)
+                {
+                    metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
+                }
+
+                Log.Error(string.Format("Http status executing FetchSegmentChanges: {0} - {1}", response.statusCode.ToString(), response.content));
+
+                return string.Empty;
             }
             catch (Exception e)
             {

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
@@ -25,11 +25,13 @@ namespace Splitio.Services.SplitFetcher.Classes
         {
             var clock = new Stopwatch();
             clock.Start();
+
             try
             {
                 var requestUri = GetRequestUri(since);
                 var response = await ExecuteGet(requestUri);
-                if (response.statusCode == HttpStatusCode.OK)
+
+                if ((int)response.statusCode >= (int)HttpStatusCode.OK && (int)response.statusCode < (int)HttpStatusCode.Ambiguous)
                 {
                     if (metricsLog != null)
                     {


### PR DESCRIPTION
## Changes

We are checking for all status code between 200 and 300.

## Notes
I would need to work significantly more to add tests, since the HttpClient is not something I can mock. There’s another approach but would require changing other pieces of the code as well. Plus the current tests that consume the HttpClient class are all ignored (I guess this is why).