### PR TITLE
Validate Traffic Types used in Track calls

### DIFF
--- a/Splitio-net-core-tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
@@ -27,7 +27,8 @@ namespace Splitio_Tests.Integration_Tests
             var splitChangesResult = splitChangeFetcher.Fetch(-1);
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
             var gates = new InMemoryReadinessGatesCache();
-            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, 30, splitCache);
+            var trafficTypeCache = new InMemoryTrafficTypesCache();
+            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, 30, trafficTypeCache, splitCache);
             selfRefreshingSplitFetcher.Start();
             gates.IsSDKReady(1000);
 
@@ -52,7 +53,8 @@ namespace Splitio_Tests.Integration_Tests
             var splitChangesResult = splitChangeFetcher.Fetch(-1);
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
             var gates = new InMemoryReadinessGatesCache();
-            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, 30, splitCache);
+            var trafficTypeCache = new InMemoryTrafficTypesCache();
+            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, 30, trafficTypeCache, splitCache);
             selfRefreshingSplitFetcher.Start();
             gates.IsSDKReady(1000);
 
@@ -83,6 +85,7 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
             };
+
             var sdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
             var apiSplitChangeFetcher = new ApiSplitChangeFetcher(sdkApiClient);
             var sdkSegmentApiClient = new SegmentSdkApiClient(httpHeader, baseUrl, 10000, 10000);
@@ -91,9 +94,10 @@ namespace Splitio_Tests.Integration_Tests
             var segmentCache = new InMemorySegmentCache(new ConcurrentDictionary<string, Segment>());
             var selfRefreshingSegmentFetcher = new SelfRefreshingSegmentFetcher(apiSegmentChangeFetcher, gates, 30, segmentCache, 4);
 
+            var trafficTypeCache = new InMemoryTrafficTypesCache();
             var splitParser = new InMemorySplitParser(selfRefreshingSegmentFetcher, segmentCache);
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
-            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(apiSplitChangeFetcher, splitParser, gates, 30, splitCache);
+            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(apiSplitChangeFetcher, splitParser, gates, 30, trafficTypeCache, splitCache);
             selfRefreshingSplitFetcher.Start();
 
             //Act           
@@ -126,13 +130,13 @@ namespace Splitio_Tests.Integration_Tests
             var sdkSegmentApiClient = new SegmentSdkApiClient(httpHeader, baseUrl, 10000, 10000);
             var apiSegmentChangeFetcher = new ApiSegmentChangeFetcher(sdkSegmentApiClient);
             var gates = new InMemoryReadinessGatesCache();
-
+            var trafficTypeCache = new InMemoryTrafficTypesCache();
             var segmentCache = new InMemorySegmentCache(new ConcurrentDictionary<string, Segment>());
 
             var selfRefreshingSegmentFetcher = new SelfRefreshingSegmentFetcher(apiSegmentChangeFetcher, gates, 30, segmentCache, 4);
             var splitParser = new InMemorySplitParser(selfRefreshingSegmentFetcher, segmentCache);
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
-            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(apiSplitChangeFetcher, splitParser, gates, 30, splitCache);
+            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(apiSplitChangeFetcher, splitParser, gates, 30, trafficTypeCache, splitCache);
             selfRefreshingSplitFetcher.Start();
 
             //Act

--- a/Splitio-net-core-tests/Unit Tests/Client/SplitClientForTesting.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitClientForTesting.cs
@@ -9,12 +9,17 @@ namespace Splitio_Tests.Unit_Tests.Client
 {
     public class SplitClientForTesting : SplitClient
     {
-        public SplitClientForTesting(ILog log, ISplitCache _splitCache, Splitter _splitter, IListener<WrappedEvent> eventListener) 
+        public SplitClientForTesting(ILog log, 
+            ISplitCache _splitCache, 
+            Splitter _splitter, 
+            IListener<WrappedEvent> _eventListener,
+            ITrafficTypesCache _trafficTypesCache)
             : base(log)
         {
             splitCache = _splitCache;
             splitter = _splitter;
-            this.eventListener = eventListener;
+            trafficTypesCache = _trafficTypesCache;
+            eventListener = _eventListener;
         }
 
         public override void Destroy()

--- a/src/Splitio-net-core/Services/Cache/Classes/InMemoryTrafficTypesCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Classes/InMemoryTrafficTypesCache.cs
@@ -1,0 +1,36 @@
+﻿using Splitio.Services.Cache.Interfaces;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Splitio.Services.Cache.Classes
+{
+    public class InMemoryTrafficTypesCache : ITrafficTypesCache
+    {
+        private ConcurrentBag<string> _trafficTypes;
+
+        public InMemoryTrafficTypesCache()
+        {
+            _trafficTypes = new ConcurrentBag<string>();
+        }
+
+        public void Load(List<string> trafficTypes)
+        {
+            foreach (var type in trafficTypes)
+            {
+                if (!Exists(type))
+                    _trafficTypes.Add(type);
+            }            
+        }
+
+        public void Clear()
+        {
+            _trafficTypes = new ConcurrentBag<string>();
+        }
+
+        public bool Exists(string trafficType)
+        {
+            return _trafficTypes.FirstOrDefault(tt => trafficType.Equals(tt)) != null;
+        }
+    }
+}

--- a/src/Splitio-net-core/Services/Cache/Classes/InMemoryTrafficTypesCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Classes/InMemoryTrafficTypesCache.cs
@@ -16,6 +16,8 @@ namespace Splitio.Services.Cache.Classes
 
         public void Load(List<string> trafficTypes)
         {
+            trafficTypes = trafficTypes.Distinct().ToList();
+
             foreach (var type in trafficTypes)
             {
                 if (!Exists(type))

--- a/src/Splitio-net-core/Services/Cache/Interfaces/ITrafficTypesCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Interfaces/ITrafficTypesCache.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Splitio.Services.Cache.Interfaces
+{
+    public interface ITrafficTypesCache
+    {
+        void Load(List<string> trafficTypes);
+        void Clear();
+        bool Exists(string trafficType);
+    }
+}

--- a/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
@@ -202,8 +202,11 @@ namespace Splitio.Services.Client.Classes
             selfRefreshingSegmentFetcher = new SelfRefreshingSegmentFetcher(segmentChangeFetcher, gates, segmentRefreshRate, segmentCache, NumberOfParalellSegmentTasks);
             var splitChangeFetcher = new ApiSplitChangeFetcher(splitSdkApiClient);
             var splitParser = new InMemorySplitParser(selfRefreshingSegmentFetcher, segmentCache);
+
             splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>(ConcurrencyLevel, InitialCapacity));
-            splitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, splitsRefreshRate, splitCache);
+            trafficTypesCache = new InMemoryTrafficTypesCache();
+
+            splitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, splitsRefreshRate, trafficTypesCache, splitCache);
         }
 
         private void BuildTreatmentLog(ConfigurationOptions config)

--- a/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
@@ -22,7 +22,6 @@ namespace Splitio.Services.Client.Classes
         protected readonly IKeyValidator _keyValidator;
         protected readonly ISplitNameValidator _splitNameValidator;
         protected readonly IEventTypeValidator _eventTypeValidator;
-        protected readonly ITrafficTypeValidator _trafficTypeValidator;
         protected readonly IEventPropertiesValidator _eventPropertiesValidator;
         protected const string Control = "control";
         protected const string SdkGetTreatment = "sdk.getTreatment";
@@ -48,6 +47,8 @@ namespace Splitio.Services.Client.Classes
         protected ISimpleCache<WrappedEvent> eventsCache;
         protected ISplitCache splitCache;
         protected ISegmentCache segmentCache;
+        protected ITrafficTypesCache trafficTypesCache;
+        protected ITrafficTypeValidator _trafficTypeValidator;
 
         private ConcurrentDictionary<string, string> treatmentCache = new ConcurrentDictionary<string, string>();
 
@@ -57,7 +58,6 @@ namespace Splitio.Services.Client.Classes
             _keyValidator = new KeyValidator(_log);
             _splitNameValidator = new SplitNameValidator(_log);
             _eventTypeValidator = new EventTypeValidator(_log);
-            _trafficTypeValidator = new TrafficTypeValidator(_log);
             _eventPropertiesValidator = new EventPropertiesValidator(_log);
         }
 
@@ -128,6 +128,7 @@ namespace Splitio.Services.Client.Classes
         public virtual bool Track(string key, string trafficType, string eventType, double? value = null, Dictionary<string, object> properties = null)
         {
             CheckClientStatus();
+            _trafficTypeValidator = new TrafficTypeValidator(_log, trafficTypesCache);
 
             var keyResult = _keyValidator.IsValid(new Key(key, null), nameof(Track));
             var trafficTypeResult = _trafficTypeValidator.IsValid(trafficType, nameof(trafficType));

--- a/src/Splitio-net-core/Services/InputValidation/Classes/TrafficTypeValidator.cs
+++ b/src/Splitio-net-core/Services/InputValidation/Classes/TrafficTypeValidator.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Logging;
 using Splitio.Domain;
+using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.InputValidation.Interfaces;
 using System.Linq;
 
@@ -7,11 +8,14 @@ namespace Splitio.Services.InputValidation.Classes
 {
     public class TrafficTypeValidator : ITrafficTypeValidator
     {
-        protected readonly ILog _log;
+        private readonly ILog _log;
+        private readonly ITrafficTypesCache _trafficTypesCache;
 
-        public TrafficTypeValidator(ILog log)
+        public TrafficTypeValidator(ILog log,
+             ITrafficTypesCache trafficTypesCache)
         {
             _log = log;
+            _trafficTypesCache = trafficTypesCache;
         }
 
         public ValidatorResult IsValid(string trafficType, string method)
@@ -33,6 +37,11 @@ namespace Splitio.Services.InputValidation.Classes
                 _log.Warn($"{method}: {trafficType} should be all lowercase - converting string to lowercase");
 
                 trafficType = trafficType.ToLower();
+            }
+
+            if (!_trafficTypesCache.Exists(trafficType))
+            {
+                _log.Warn($"Track: Traffic Type {trafficType} does not have any corresponding Splits in this environment, make sure you’re tracking your events to a valid traffic type defined in the Split console.");
             }
 
             return new ValidatorResult { Success = true, Value = trafficType };


### PR DESCRIPTION
- Created a cache of all the Traffic Type that have been returned in the Split definitions that have come from /splitChanges
- Now we validate If the Traffic Type used in Track calls does not match we log a warning.