### PR TITLE
Change logging framework

### DIFF
--- a/Splitio-net-core-tests/Integration Tests/AsynchronousImpressionListenerTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/AsynchronousImpressionListenerTests.cs
@@ -1,7 +1,7 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
 using System.Collections.Generic;
@@ -40,7 +40,7 @@ namespace Splitio_Tests.Integration_Tests
         public void AddTwoListenersAndPerformLogSuccessfully()
         {
             //Arrange
-            var logger = new Mock<ILog>();
+            var logger = new Mock<ISplitLogger>();
             var asyncListener = new AsynchronousListener<KeyImpression>(logger.Object);
             var listener1 = new TestListener();
             var listenerMock2 = new Mock<IListener<KeyImpression>>();
@@ -49,7 +49,7 @@ namespace Splitio_Tests.Integration_Tests
 
 
             //Act
-            asyncListener.Log(new KeyImpression() { feature = "test", changeNumber = 100, keyName = "date", label = "testdate", time = 10000000, treatment = "on", bucketingKey = "any" });
+            asyncListener.Log(new KeyImpression { feature = "test", changeNumber = 100, keyName = "date", label = "testdate", time = 10000000, treatment = "on", bucketingKey = "any" });
             Thread.Sleep(1000);
 
             //Assert
@@ -61,7 +61,7 @@ namespace Splitio_Tests.Integration_Tests
         public void AddTwoListenersAndPerformLogSuccessfullyWithOneLongRunningTask()
         {
             //Arrange
-            var logger = new Mock<ILog>();
+            var logger = new Mock<ISplitLogger>();
             var asyncListener = new AsynchronousListener<KeyImpression>(logger.Object);
             var listener1 = new TestListener2();
             var listener2 = new TestListener();

--- a/Splitio-net-core-tests/Integration Tests/JSONFileClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/JSONFileClientTests.cs
@@ -1,11 +1,11 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Client.Classes;
 using Splitio.Services.Impressions.Classes;
 using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
 using System;
@@ -17,12 +17,12 @@ namespace Splitio_Tests.Integration_Tests
     [TestClass]
     public class JSONFileClientTests
     {
-        private readonly Mock<ILog> _logMock;
+        private readonly Mock<ISplitLogger> _logMock;
         private readonly string rootFilePath;
 
         public JSONFileClientTests()
         {
-            _logMock = new Mock<ILog>();
+            _logMock = new Mock<ISplitLogger>();
 
             // This line is to clean the warnings.
             rootFilePath = string.Empty;

--- a/Splitio-net-core-tests/Integration Tests/LocalhostClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/LocalhostClientTests.cs
@@ -1,5 +1,4 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Services.Client.Classes;
 using Splitio.Services.Shared.Interfaces;
@@ -13,14 +12,12 @@ namespace Splitio_Tests.Integration_Tests
     [TestClass]
     public class LocalhostClientTests
     {
-        private readonly Mock<ILog> _logMock;
         private readonly Mock<IFactoryInstantiationsService> _factoryInstantiationsServiceMock;
 
         private readonly string rootFilePath;
 
         public LocalhostClientTests()
         {
-            _logMock = new Mock<ILog>();
             _factoryInstantiationsServiceMock = new Mock<IFactoryInstantiationsService>();
 
             // This line is to clean the warnings.
@@ -36,7 +33,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentSuccessfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}test.splits", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}test.splits");
 
             client.BlockUntilReady(1000);
 
@@ -59,7 +56,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentSuccessfullyWhenUpdatingSplitsFile()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}test.splits", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}test.splits");
 
             client.BlockUntilReady(1000);
 
@@ -88,7 +85,7 @@ namespace Splitio_Tests.Integration_Tests
         public void ClientDestroySuccessfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}test.splits", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}test.splits");
 
             client.BlockUntilReady(1000);
 
@@ -120,7 +117,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatment_WhenIsYamlFile_Successfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}split.yaml", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}split.yaml");
 
             client.BlockUntilReady(1000);
 
@@ -152,7 +149,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentWithConfig_WhenIsYamlFile_Successfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}split.yaml", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}split.yaml");
 
             client.BlockUntilReady(1000);
 
@@ -191,7 +188,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatment_WhenIsYmlFile_Successfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}split.yml", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}split.yml");
 
             client.BlockUntilReady(1000);
 
@@ -223,7 +220,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentWithConfig_WhenIsYmlFile_Successfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}split.yml", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}split.yml");
 
             client.BlockUntilReady(1000);
 
@@ -262,7 +259,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatments_WhenIsYamlFile_Successfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}split.yaml", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}split.yaml");
 
             client.BlockUntilReady(1000);
 
@@ -299,7 +296,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentsWithConfig_WhenIsYamlFile_Successfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}split.yaml", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}split.yaml");
 
             client.BlockUntilReady(1000);
 
@@ -350,7 +347,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatments_WhenIsYmlFile_Successfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}split.yml", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}split.yml");
 
             client.BlockUntilReady(1000);
 
@@ -387,7 +384,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentsWithConfig_WhenIsYmlFile_Successfully()
         {
             //Arrange
-            var client = new LocalhostClient($"{rootFilePath}split.yml", _logMock.Object);
+            var client = new LocalhostClient($"{rootFilePath}split.yml");
 
             client.BlockUntilReady(1000);
 

--- a/Splitio-net-core-tests/Integration Tests/RedisClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/RedisClientTests.cs
@@ -1,10 +1,10 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Redis.Services.Cache.Classes;
 using Splitio.Redis.Services.Cache.Interfaces;
 using Splitio.Redis.Services.Client.Classes;
 using Splitio.Services.Client.Classes;
+using Splitio.Services.Logger;
 using Splitio_Tests.Resources;
 using System.Collections.Generic;
 
@@ -20,7 +20,7 @@ namespace Splitio_Tests.Integration_Tests
         private const string API_KEY = "redis_api_key";
 
         private ConfigurationOptions config;
-        private Mock<ILog> _logMock = new Mock<ILog>();
+        private Mock<ISplitLogger> _logMock = new Mock<ISplitLogger>();
         private IRedisAdapter _redisAdapter;
 
         [TestInitialize]
@@ -46,7 +46,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatment_WhenFeatureExists_ReturnsOn()
         {
             //Arrange
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
 
             client.BlockUntilReady(1000);
 
@@ -62,7 +62,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatment_WhenFeatureExists_ReturnsOff()
         {
             //Arrange
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
 
             client.BlockUntilReady(1000);
 
@@ -78,7 +78,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatment_WhenFeatureDoenstExist_ReturnsControl()
         {
             //Arrange
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
             client.BlockUntilReady(1000);
 
             //Act           
@@ -98,7 +98,7 @@ namespace Splitio_Tests.Integration_Tests
 
             var features = new List<string> { alwaysOn, alwaysOff };
 
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
 
             client.BlockUntilReady(1000);
 
@@ -121,7 +121,7 @@ namespace Splitio_Tests.Integration_Tests
 
             var features = new List<string> { alwaysOn, alwaysOff, alwaysControl };
 
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
 
             client.BlockUntilReady(1000);
 
@@ -139,7 +139,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentsWithConfig_WhenClientIsNotReady_ReturnsControl()
         {
             // Arrange.
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
             
             // Act.
             var result = client.GetTreatmentsWithConfig("key", new List<string>());
@@ -158,7 +158,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatmentWithConfig_WhenClientIsNotReady_ReturnsControl()
         {
             // Arrange.
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
 
             // Act.
             var result = client.GetTreatmentWithConfig("key", string.Empty);
@@ -172,7 +172,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatment_WhenClientIsNotReady_ReturnsControl()
         {
             // Arrange.
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
 
             // Act.
             var result = client.GetTreatment("key", string.Empty);
@@ -186,7 +186,7 @@ namespace Splitio_Tests.Integration_Tests
         public void GetTreatments_WhenClientIsNotReady_ReturnsControl()
         {
             // Arrange.
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
 
             // Act.
             var result = client.GetTreatments("key", new List<string>());
@@ -204,7 +204,7 @@ namespace Splitio_Tests.Integration_Tests
         public void Track_WhenClientIsNotReady_ReturnsTrue()
         {
             // Arrange.
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
 
             // Act.
             var result = client.Track("key", "traffic_type", "event_type");
@@ -218,7 +218,7 @@ namespace Splitio_Tests.Integration_Tests
         public void Destroy()
         {
             //Arrange
-            var client = new RedisClient(config, _logMock.Object, API_KEY);
+            var client = new RedisClient(config, API_KEY, _logMock.Object);
             client.BlockUntilReady(1000);
 
             //Act

--- a/Splitio-net-core-tests/Unit Tests/Client/LocalhostClientForTesting.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/LocalhostClientForTesting.cs
@@ -1,7 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Client.Classes;
 using Splitio.Services.EngineEvaluator;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Interfaces;
 
 namespace Splitio_Tests.Unit_Tests.Client
@@ -9,7 +9,7 @@ namespace Splitio_Tests.Unit_Tests.Client
     public class LocalhostClientForTesting : LocalhostClient
     {
         public LocalhostClientForTesting(string filePath,
-            ILog log,
+            ISplitLogger log = null,
             ISplitter splitter = null,
             bool isDestroyed = false) : base(filePath, log)
         {

--- a/Splitio-net-core-tests/Unit Tests/Client/LocalhostClientUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/LocalhostClientUnitTests.cs
@@ -1,6 +1,4 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Splitio.Domain;
 using Splitio.Services.Client.Classes;
 using Splitio.Services.Shared.Classes;
@@ -9,15 +7,11 @@ namespace Splitio_Tests.Unit_Tests.Client
 {
     [TestClass]
     public class LocalhostClientUnitTests
-    {
-        private readonly Mock<ILog> _logMock;
-
+    {        
         private readonly string rootFilePath;
 
         public LocalhostClientUnitTests()
         {
-            _logMock = new Mock<ILog>();
-
             // This line is to clean the warnings.
             rootFilePath = string.Empty;
 
@@ -31,7 +25,7 @@ namespace Splitio_Tests.Unit_Tests.Client
         public void GetTreatmentShouldReturnControlIfSplitNotFound()
         {
             //Arrange
-            var splitClient = new LocalhostClient($"{rootFilePath}test.splits", _logMock.Object);
+            var splitClient = new LocalhostClient($"{rootFilePath}test.splits");
 
             //Act
             var result = splitClient.GetTreatment("test", "test");
@@ -44,7 +38,7 @@ namespace Splitio_Tests.Unit_Tests.Client
         [DeploymentItem(@"Resources\test.splits")]
         public void GetTreatmentShouldRunAsSingleKeyUsingNullBucketingKey()
         {
-            var splitClient = new LocalhostClient($"{rootFilePath}test.splits", _logMock.Object);
+            var splitClient = new LocalhostClient($"{rootFilePath}test.splits");
             splitClient.BlockUntilReady(1000);
 
             //Act
@@ -60,7 +54,7 @@ namespace Splitio_Tests.Unit_Tests.Client
         public void TrackShouldNotStoreEvents()
         {
             //Arrange
-            var splitClient = new LocalhostClientForTesting($"{rootFilePath}test.splits", _logMock.Object);
+            var splitClient = new LocalhostClientForTesting($"{rootFilePath}test.splits");
             splitClient.BlockUntilReady(1000);
                       
             //Act
@@ -76,8 +70,8 @@ namespace Splitio_Tests.Unit_Tests.Client
         public void Destroy()
         {
             //Arrange
-            var _factoryInstantiationsService = FactoryInstantiationsService.Instance(_logMock.Object);
-            var splitClient = new LocalhostClientForTesting($"{rootFilePath}test.splits", _logMock.Object);
+            var _factoryInstantiationsService = FactoryInstantiationsService.Instance();
+            var splitClient = new LocalhostClientForTesting($"{rootFilePath}test.splits");
 
             //Act
             splitClient.BlockUntilReady(1000);
@@ -94,8 +88,8 @@ namespace Splitio_Tests.Unit_Tests.Client
         public void Destroy_WhenIsDestroyed()
         {
             //Arrange
-            var _factoryInstantiationsService = FactoryInstantiationsService.Instance(_logMock.Object);
-            var splitClient = new LocalhostClientForTesting($"{rootFilePath}test.splits", _logMock.Object, isDestroyed: true);
+            var _factoryInstantiationsService = FactoryInstantiationsService.Instance();
+            var splitClient = new LocalhostClientForTesting($"{rootFilePath}test.splits", isDestroyed: true);
 
             //Act
             splitClient.BlockUntilReady(1000);

--- a/Splitio-net-core-tests/Unit Tests/Client/SplitClientForTesting.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitClientForTesting.cs
@@ -1,16 +1,16 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Client.Classes;
 using Splitio.Services.Evaluator;
 using Splitio.Services.InputValidation.Classes;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Interfaces;
 
 namespace Splitio_Tests.Unit_Tests.Client
 {
     public class SplitClientForTesting : SplitClient
     {
-        public SplitClientForTesting(ILog _log, 
+        public SplitClientForTesting(ISplitLogger _log, 
             ISplitCache _splitCache, 
             IListener<WrappedEvent> _eventListener,
             IListener<KeyImpression> _impressionListener,
@@ -22,7 +22,7 @@ namespace Splitio_Tests.Unit_Tests.Client
             eventListener = _eventListener;
             impressionListener = _impressionListener;
             _blockUntilReadyService = blockUntilReadyService;
-            _trafficTypeValidator = new TrafficTypeValidator(_log, _splitCache);
+            _trafficTypeValidator = new TrafficTypeValidator(_splitCache, _log);
             _evaluator = evaluator;
 
             ApiKey = "SplitClientForTesting";

--- a/Splitio-net-core-tests/Unit Tests/Client/SplitClientUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitClientUnitTests.cs
@@ -1,9 +1,9 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Evaluator;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Interfaces;
 using System.Collections.Generic;
 
@@ -12,7 +12,7 @@ namespace Splitio_Tests.Unit_Tests.Client
     [TestClass]
     public class SplitClientUnitTests
     {        
-        private Mock<ILog> _logMock;
+        private Mock<ISplitLogger> _logMock;
         private Mock<IListener<WrappedEvent>> _eventListenerMock;
         private Mock<ISplitCache> _splitCacheMock;
         private Mock<IListener<KeyImpression>> _impressionListenerMock;
@@ -25,7 +25,7 @@ namespace Splitio_Tests.Unit_Tests.Client
         [TestInitialize]
         public void TestInitialize()
         {
-            _logMock = new Mock<ILog>();
+            _logMock = new Mock<ISplitLogger>();
             _splitCacheMock = new Mock<ISplitCache>();
             _combiningMatcher = new Mock<CombiningMatcher>();
             _eventListenerMock = new Mock<IListener<WrappedEvent>>();
@@ -52,7 +52,6 @@ namespace Splitio_Tests.Unit_Tests.Client
 
             // Assert
             Assert.AreEqual("control", result);
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -68,7 +67,6 @@ namespace Splitio_Tests.Unit_Tests.Client
 
             // Assert
             Assert.AreEqual("control", result);
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -84,7 +82,6 @@ namespace Splitio_Tests.Unit_Tests.Client
 
             // Assert
             Assert.AreEqual("control", result);
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -123,7 +120,6 @@ namespace Splitio_Tests.Unit_Tests.Client
             // Assert
             Assert.AreEqual("control", result.Treatment);
             Assert.IsNull(result.Config);
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -140,7 +136,6 @@ namespace Splitio_Tests.Unit_Tests.Client
             // Assert
             Assert.AreEqual("control", result.Treatment);
             Assert.IsNull(result.Config);
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -461,8 +456,6 @@ namespace Splitio_Tests.Unit_Tests.Client
                 Assert.AreEqual("control", res.Value.Treatment);
                 Assert.IsNull(res.Value.Config);
             }
-
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -482,8 +475,6 @@ namespace Splitio_Tests.Unit_Tests.Client
                 Assert.AreEqual("control", res.Value.Treatment);
                 Assert.IsNull(res.Value.Config);
             }
-
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -614,7 +605,6 @@ namespace Splitio_Tests.Unit_Tests.Client
 
             // Assert
             Assert.IsFalse(result);
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(4));
         }
 
         [TestMethod]
@@ -630,7 +620,6 @@ namespace Splitio_Tests.Unit_Tests.Client
 
             // Assert
             Assert.IsFalse(result);
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(4));
         }
 
         [TestMethod]
@@ -646,7 +635,6 @@ namespace Splitio_Tests.Unit_Tests.Client
 
             // Assert
             Assert.IsFalse(result);
-            _logMock.Verify(x => x.Error(It.IsAny<string>()), Times.Exactly(4));
         }
 
         [TestMethod]
@@ -689,7 +677,6 @@ namespace Splitio_Tests.Unit_Tests.Client
 
             // Assert.
             Assert.IsTrue(result);
-            _logMock.Verify(mock => mock.Warn("Property Splitio.Domain.ParsedSplit is of invalid type. Setting value to null"), Times.Once);
             _eventListenerMock.Verify(mock => mock.Log(It.Is<WrappedEvent>(we => we.Event.properties != null
                                                                               && we.Event.key.Equals("key")
                                                                               && we.Event.eventTypeId.Equals("event_type")

--- a/Splitio-net-core-tests/Unit Tests/Client/SplitFactoryUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Client/SplitFactoryUnitTests.cs
@@ -78,12 +78,16 @@ namespace Splitio_Tests.Unit_Tests.Client
         public void BuildSplitClientWithRedisConfigShouldReturnRedisSplitClient()
         {
             //Arrange
-            var configurationOptions = new ConfigurationOptions();
-            configurationOptions.Mode = Mode.Consumer;
-            configurationOptions.CacheAdapterConfig = new CacheAdapterConfigurationOptions();
-            configurationOptions.CacheAdapterConfig.Host = "local";
-            configurationOptions.CacheAdapterConfig.Port = "1234";
-            configurationOptions.CacheAdapterConfig.Password = "test";
+            var configurationOptions = new ConfigurationOptions
+            {
+                Mode = Mode.Consumer,
+                CacheAdapterConfig = new CacheAdapterConfigurationOptions
+                {
+                    Host = "local",
+                    Port = "1234",
+                    Password = "test"
+                }
+            };
 
             var factory = new SplitFactory("any", configurationOptions);
 

--- a/Splitio-net-core-tests/Unit Tests/Evaluator/EvaluatorTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Evaluator/EvaluatorTests.cs
@@ -1,10 +1,10 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.EngineEvaluator;
 using Splitio.Services.Evaluator;
+using Splitio.Services.Logger;
 using Splitio.Services.Parsing;
 using Splitio.Services.Parsing.Classes;
 using Splitio.Services.Parsing.Interfaces;
@@ -17,7 +17,7 @@ namespace Splitio_Tests.Unit_Tests.Evaluator
     public class EvaluatorTests
     {
         private readonly Mock<ISplitter> _splitter;
-        private readonly Mock<ILog> _log;
+        private readonly Mock<ISplitLogger> _log;
         private readonly Mock<ISplitParser> _splitParser;
         private readonly Mock<ISplitCache> _splitCache;
 
@@ -26,7 +26,7 @@ namespace Splitio_Tests.Unit_Tests.Evaluator
         public EvaluatorTests()
         {
             _splitter = new Mock<ISplitter>();
-            _log = new Mock<ILog>();
+            _log = new Mock<ISplitLogger>();
             _splitParser = new Mock<ISplitParser>();
             _splitCache = new Mock<ISplitCache>();
 

--- a/Splitio-net-core-tests/Unit Tests/Events/AsynchronousEventListenerUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Events/AsynchronousEventListenerUnitTests.cs
@@ -1,7 +1,7 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
 using System;
@@ -12,14 +12,14 @@ namespace Splitio_Tests.Unit_Tests.Events
     [TestClass]
     public class AsynchronousEventListenerUnitTests
     {
-        private Mock<ILog> _logger;
+        private Mock<ISplitLogger> _logger;
         private AsynchronousListener<Event> _asyncListener;
         private Mock<IListener<Event>> _listenerMock;
 
         [TestInitialize]
         public void Initialize()
         {
-            _logger = new Mock<ILog>();
+            _logger = new Mock<ISplitLogger>();
             _asyncListener = new AsynchronousListener<Event>(_logger.Object);
             _listenerMock = new Mock<IListener<Event>>();
         }

--- a/Splitio-net-core-tests/Unit Tests/Impressions/AsynchronousImpressionListenerUnitTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Impressions/AsynchronousImpressionListenerUnitTests.cs
@@ -1,7 +1,7 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
 using System;
@@ -12,14 +12,14 @@ namespace Splitio_Tests.Unit_Tests.Impressions
     [TestClass]
     public class AsynchronousImpressionListenerUnitTests
     {
-        private Mock<ILog> _logger;
+        private Mock<ISplitLogger> _logger;
         private AsynchronousListener<KeyImpression> _asyncListener;
         private Mock<IListener<KeyImpression>> _listenerMock;
 
         [TestInitialize]
         public void Initialize()
         {
-            _logger = new Mock<ILog>();
+            _logger = new Mock<ISplitLogger>();
             _asyncListener = new AsynchronousListener<KeyImpression>(_logger.Object);
             _listenerMock = new Mock<IListener<KeyImpression>>();
         }

--- a/Splitio-net-core-tests/Unit Tests/InputValidation/ApiKeyValidatorTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/InputValidation/ApiKeyValidatorTests.cs
@@ -1,20 +1,20 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Services.InputValidation.Classes;
+using Splitio.Services.Logger;
 
 namespace Splitio_Tests.Unit_Tests.InputValidation
 {
     [TestClass]
     public class ApiKeyValidatorTests
     {
-        private Mock<ILog> _log;
+        private Mock<ISplitLogger> _log;
         private ApiKeyValidator apiKeyValidator;
 
         [TestInitialize]
         public void Initialize()
         {
-            _log = new Mock<ILog>();
+            _log = new Mock<ISplitLogger>();
 
             apiKeyValidator = new ApiKeyValidator(_log.Object);
         }

--- a/Splitio-net-core-tests/Unit Tests/InputValidation/EventPropertiesValidatorTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/InputValidation/EventPropertiesValidatorTests.cs
@@ -1,8 +1,8 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
 using Splitio.Services.InputValidation.Classes;
+using Splitio.Services.Logger;
 using Splitio_Tests.Resources;
 using System.Collections.Generic;
 
@@ -11,13 +11,13 @@ namespace Splitio_Tests.Unit_Tests.InputValidation
     [TestClass]
     public class EventPropertiesValidatorTests
     {
-        private Mock<ILog> _log;
+        private Mock<ISplitLogger> _log;
         private EventPropertiesValidator eventPropertiesValidator;
 
         [TestInitialize]
         public void Initialize()
         {
-            _log = new Mock<ILog>();
+            _log = new Mock<ISplitLogger>();
 
             eventPropertiesValidator = new EventPropertiesValidator(_log.Object);
         }

--- a/Splitio-net-core-tests/Unit Tests/InputValidation/EventTypeValidatorTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/InputValidation/EventTypeValidatorTests.cs
@@ -1,20 +1,20 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Services.InputValidation.Classes;
+using Splitio.Services.Logger;
 
 namespace Splitio_Tests.Unit_Tests.InputValidation
 {
     [TestClass]
     public class EventTypeValidatorTests
     {
-        private Mock<ILog> _log;
+        private Mock<ISplitLogger> _log;
         private EventTypeValidator eventTypeValidator;
 
         [TestInitialize]
         public void Initialize()
         {
-            _log = new Mock<ILog>();
+            _log = new Mock<ISplitLogger>();
 
             eventTypeValidator = new EventTypeValidator(_log.Object);
         }

--- a/Splitio-net-core-tests/Unit Tests/InputValidation/KeyValidatorTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/InputValidation/KeyValidatorTests.cs
@@ -1,21 +1,21 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
 using Splitio.Services.InputValidation.Classes;
+using Splitio.Services.Logger;
 
 namespace Splitio_Tests.Unit_Tests.InputValidation
 {
     [TestClass]
     public class KeyValidatorTests
     {
-        private Mock<ILog> _log;
+        private Mock<ISplitLogger> _log;
         private KeyValidator keyValidator;
 
         [TestInitialize]
         public void Initialize()
         {
-            _log = new Mock<ILog>();
+            _log = new Mock<ISplitLogger>();
 
             keyValidator = new KeyValidator(_log.Object);
         }

--- a/Splitio-net-core-tests/Unit Tests/InputValidation/SplitNameValidatorTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/InputValidation/SplitNameValidatorTests.cs
@@ -1,7 +1,7 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Services.InputValidation.Classes;
+using Splitio.Services.Logger;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,13 +10,13 @@ namespace Splitio_Tests.Unit_Tests.InputValidation
     [TestClass]
     public class SplitNameValidatorTests
     {
-        private Mock<ILog> _log;
+        private Mock<ISplitLogger> _log;
         private SplitNameValidator splitNameValidator;
 
         [TestInitialize]
         public void Initialize()
         {
-            _log = new Mock<ILog>();
+            _log = new Mock<ISplitLogger>();
 
             splitNameValidator = new SplitNameValidator(_log.Object);
         }

--- a/Splitio-net-core-tests/Unit Tests/InputValidation/TrafficTypeValidatorTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/InputValidation/TrafficTypeValidatorTests.cs
@@ -1,25 +1,25 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.InputValidation.Classes;
+using Splitio.Services.Logger;
 
 namespace Splitio_Tests.Unit_Tests.InputValidation
 {
     [TestClass]
     public class TrafficTypeValidatorTests
     {
-        private Mock<ILog> _log;
+        private Mock<ISplitLogger> _log;
         private Mock<ISplitCache> _splitCache;
         private TrafficTypeValidator trafficTypeValidator;
 
         [TestInitialize]
         public void Initialize()
         {
-            _log = new Mock<ILog>();
+            _log = new Mock<ISplitLogger>();
             _splitCache = new Mock<ISplitCache>();
 
-            trafficTypeValidator = new TrafficTypeValidator(_log.Object, _splitCache.Object);
+            trafficTypeValidator = new TrafficTypeValidator(_splitCache.Object, _log.Object);
         }
 
         [TestMethod]

--- a/Splitio-net-core-tests/Unit Tests/Shared/FactoryInstantiationsServiceTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Shared/FactoryInstantiationsServiceTests.cs
@@ -1,6 +1,6 @@
-﻿using Common.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Classes;
 
 namespace Splitio_Tests.Unit_Tests.Shared
@@ -8,13 +8,13 @@ namespace Splitio_Tests.Unit_Tests.Shared
     [TestClass]
     public class FactoryInstantiationsServiceTests
     {
-        private readonly Mock<ILog> _logMock;
+        private readonly Mock<ISplitLogger> _logMock;
 
         private FactoryInstantiationsService _factoryInstantiationsService;
 
         public FactoryInstantiationsServiceTests()
         {
-            _logMock = new Mock<ILog>();
+            _logMock = new Mock<ISplitLogger>();
 
             _factoryInstantiationsService = (FactoryInstantiationsService)FactoryInstantiationsService.Instance(_logMock.Object);
         }

--- a/Splitio-net-core.Integration-tests/BaseIntegrationTests.cs
+++ b/Splitio-net-core.Integration-tests/BaseIntegrationTests.cs
@@ -633,6 +633,7 @@ namespace Splitio_net_core.Integration_tests
             var result = manager.Split(splitName);
 
             // Assert.
+            Assert.IsNotNull(result);
             Assert.AreEqual(splitName, result.name);
 
             ShutdownServer(httpClientMock);

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisAdapter.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisAdapter.cs
@@ -281,7 +281,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter ListRange", e);
+                _log.Error("Exception calling Redis Adapter ListRange", e);
                 return new RedisValue[0];
             }
         }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisAdapter.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisAdapter.cs
@@ -1,5 +1,6 @@
-﻿using Common.Logging;
-using Splitio.Redis.Services.Cache.Interfaces;
+﻿using Splitio.Redis.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using StackExchange.Redis;
 using System;
 using System.Linq;
@@ -8,14 +9,19 @@ namespace Splitio.Redis.Services.Cache.Classes
 {
     public class RedisAdapter : IRedisAdapter
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(RedisAdapter));
+        private static readonly ISplitLogger _log = WrapperAdapter.GetLogger(typeof(RedisAdapter));
 
         private ConnectionMultiplexer redis;
         private IDatabase database;
         private IServer server;
 
-        public RedisAdapter(string host, string port, string password = "", int databaseNumber = 0,
-            int connectTimeout = 0, int connectRetry = 0, int syncTimeout = 0)
+        public RedisAdapter(string host, 
+            string port, 
+            string password = "", 
+            int databaseNumber = 0,
+            int connectTimeout = 0, 
+            int connectRetry = 0, 
+            int syncTimeout = 0)
         {
             try
             {
@@ -26,7 +32,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error(string.Format("Exception caught building Redis Adapter '{0}:{1}': ", host, port), e);
+                _log.Error(string.Format("Exception caught building Redis Adapter '{0}:{1}': ", host, port), e);
             }
         }
 
@@ -67,7 +73,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter Set", e);
+                _log.Error("Exception calling Redis Adapter Set", e);
                 return false;
             }
         }
@@ -80,7 +86,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter Get", e);
+                _log.Error("Exception calling Redis Adapter Get", e);
                 return string.Empty;
             }
         }
@@ -93,7 +99,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter Get", e);
+                _log.Error("Exception calling Redis Adapter Get", e);
                 return new RedisValue[0];
             }
         }
@@ -107,7 +113,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter Keys", e);
+                _log.Error("Exception calling Redis Adapter Keys", e);
                 return new RedisKey[0];
             }
         }
@@ -120,7 +126,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter Del", e);
+                _log.Error("Exception calling Redis Adapter Del", e);
                 return false;
             }
         }
@@ -133,7 +139,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter Del", e);
+                _log.Error("Exception calling Redis Adapter Del", e);
                 return 0;
             }
         }
@@ -146,7 +152,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter SAdd", e);
+                _log.Error("Exception calling Redis Adapter SAdd", e);
                 return false;
             }
         }
@@ -159,7 +165,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter SAdd", e);
+                _log.Error("Exception calling Redis Adapter SAdd", e);
                 return 0;
             }
         }
@@ -172,7 +178,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter SRem", e);
+                _log.Error("Exception calling Redis Adapter SRem", e);
                 return 0;
             }
         }
@@ -185,7 +191,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter SIsMember", e);
+                _log.Error("Exception calling Redis Adapter SIsMember", e);
                 return false;
             }
         }
@@ -198,7 +204,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter SMembers", e);
+                _log.Error("Exception calling Redis Adapter SMembers", e);
                 return new RedisValue[0];
             }
         }
@@ -211,7 +217,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter IcrBy", e);
+                _log.Error("Exception calling Redis Adapter IcrBy", e);
                 return 0;
             }
         }
@@ -224,7 +230,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter ListRightPush", e);
+                _log.Error("Exception calling Redis Adapter ListRightPush", e);
                 return 0;
             }
         }
@@ -237,7 +243,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter Flush", e);
+                _log.Error("Exception calling Redis Adapter Flush", e);
             }
         }
 
@@ -249,7 +255,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter KeyExpire", e);
+                _log.Error("Exception calling Redis Adapter KeyExpire", e);
                 return false;
             }
         }
@@ -262,7 +268,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
             catch (Exception e)
             {
-                Log.Error("Exception calling Redis Adapter ListRightPush", e);
+                _log.Error("Exception calling Redis Adapter ListRightPush", e);
                 return 0;
             }
         }

--- a/Splitio-net-core.Redis/Splitio.Redis.csproj
+++ b/Splitio-net-core.Redis/Splitio.Redis.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>5.0.4</Version>
+    <Version>5.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">

--- a/Splitio-net-core.Redis/Splitio.Redis.csproj
+++ b/Splitio-net-core.Redis/Splitio.Redis.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>5.0.2</Version>
+    <Version>5.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">

--- a/Splitio-net-core.Redis/Splitio.Redis.csproj
+++ b/Splitio-net-core.Redis/Splitio.Redis.csproj
@@ -16,14 +16,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="Common.Logging" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45'">
-    <PackageReference Include="Common.Logging" version="3.3.1" />
-    <PackageReference Include="Common.Logging.Core" version="3.3.1" />
     <PackageReference Include="Newtonsoft.Json" version="9.0.1" />
   </ItemGroup>
 

--- a/Splitio-net-core.Redis/Splitio.Redis.csproj
+++ b/Splitio-net-core.Redis/Splitio.Redis.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net40;net45</TargetFrameworks>
-    <AssemblyName>Splitio-net-core.Redis</AssemblyName>
-    <PackageId>Splitio-net-core.Redis</PackageId>
+    <AssemblyName>Splitio.Redis</AssemblyName>
+    <PackageId>Splitio.Redis</PackageId>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/Splitio-net-core.Redis/Splitio.Redis.csproj
+++ b/Splitio-net-core.Redis/Splitio.Redis.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net40;net45</TargetFrameworks>
@@ -8,7 +8,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>5.1.0</Version>
+    <Version>6.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">

--- a/Splitio.TestSupport/Samples/SampleTest.cs
+++ b/Splitio.TestSupport/Samples/SampleTest.cs
@@ -1,20 +1,19 @@
-﻿using Common.Logging;
-using Moq;
+﻿using Moq;
 using Splitio.Services.Client.Classes;
-using Splitio.Services.Shared.Interfaces;
+using Splitio.Services.Logger;
 using Xunit;
 
 namespace Splitio.TestSupport.Samples
 {
     public class SampleTest
     {
-        private readonly Mock<ILog> _logMock;
+        private readonly Mock<ISplitLogger> _logMock;
         
         private SplitClientForTest splitClient;
 
         public SampleTest()
         {
-            _logMock = new Mock<ILog>();
+            _logMock = new Mock<ISplitLogger>();
 
             splitClient = new SplitClientForTest(_logMock.Object);
         }

--- a/Splitio.TestSupport/SplitClientForTest.cs
+++ b/Splitio.TestSupport/SplitClientForTest.cs
@@ -1,5 +1,5 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
+using Splitio.Services.Logger;
 using System.Collections.Generic;
 
 namespace Splitio.Services.Client.Classes
@@ -8,7 +8,7 @@ namespace Splitio.Services.Client.Classes
     {
         private Dictionary<string, string> _tests;
 
-        public SplitClientForTest(ILog log) : base(log)
+        public SplitClientForTest(ISplitLogger log) : base(log)
         {
             _tests = new Dictionary<string, string>();
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 nuget:
   account_feed: true
 
-version: 5.1.0-rc{build}
+version: 6.0.0-rc{build}
 
 dotnet_csproj:
   patch: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 nuget:
   account_feed: true
 
-version: 5.0.3-rc{build}
+version: 5.1.0-rc{build}
 
 dotnet_csproj:
   patch: true

--- a/src/Splitio-net-core/CommonLibraries/SdkApiClient.cs
+++ b/src/Splitio-net-core/CommonLibraries/SdkApiClient.cs
@@ -1,5 +1,6 @@
-﻿using Common.Logging;
+﻿using Splitio.Services.Logger;
 using Splitio.Services.Metrics.Interfaces;
+using Splitio.Services.Shared.Classes;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -11,8 +12,9 @@ namespace Splitio.CommonLibraries
 {
     public class SdkApiClient : ISdkApiClient
     {
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SdkApiClient));
+
         private HttpClient httpClient;
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SdkApiClient));
         protected IMetricsLog metricsLog;
 
         public SdkApiClient (HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null)

--- a/src/Splitio-net-core/Services/Cache/Classes/InMemoryReadinessGatesCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Classes/InMemoryReadinessGatesCache.cs
@@ -47,7 +47,7 @@ namespace Splitio.Services.Client.Classes
                 if (splitsAreReady.IsSet)
                 {
                     _splitsReadyTimer.Stop();
-                    if (Log.IsDebugEnabled())
+                    if (Log.IsDebugEnabled)
                     {
                         Log.Debug($"Splits are ready in {_splitsReadyTimer.ElapsedMilliseconds} milliseconds");
                     }
@@ -69,7 +69,7 @@ namespace Splitio.Services.Client.Classes
 
             if (countDown.IsSet)
             {
-                if (Log.IsDebugEnabled())
+                if (Log.IsDebugEnabled)
                 {
                     Log.Debug(segmentName + " segment is ready");
                 }
@@ -91,7 +91,7 @@ namespace Splitio.Services.Client.Classes
             try
             {
                 segmentsAreReady.Add(segmentName, new CountdownEvent(1));
-                if (Log.IsDebugEnabled())
+                if (Log.IsDebugEnabled)
                 {
                     Log.Debug("Registered segment: " + segmentName);
                 }
@@ -133,7 +133,7 @@ namespace Splitio.Services.Client.Classes
             }
 
             _segmentsReadyTimer.Stop();
-            if (Log.IsDebugEnabled())
+            if (Log.IsDebugEnabled)
             {
                 Log.Debug($"Segments are ready in {_segmentsReadyTimer.ElapsedMilliseconds} milliseconds");
             }

--- a/src/Splitio-net-core/Services/Cache/Classes/InMemoryReadinessGatesCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Classes/InMemoryReadinessGatesCache.cs
@@ -1,15 +1,17 @@
-﻿using System;
+﻿using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
+using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Diagnostics;
-using Common.Logging;
-using Splitio.Services.Cache.Interfaces;
+using System.Threading;
 
 namespace Splitio.Services.Client.Classes
 {
     public class InMemoryReadinessGatesCache : IReadinessGatesCache
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(InMemoryReadinessGatesCache));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(InMemoryReadinessGatesCache));
+
         private readonly CountdownEvent splitsAreReady = new CountdownEvent(1);
         private readonly Dictionary<string, CountdownEvent> segmentsAreReady = new Dictionary<string, CountdownEvent>();
         private readonly Stopwatch _splitsReadyTimer = new Stopwatch();
@@ -45,7 +47,7 @@ namespace Splitio.Services.Client.Classes
                 if (splitsAreReady.IsSet)
                 {
                     _splitsReadyTimer.Stop();
-                    if (Log.IsDebugEnabled)
+                    if (Log.IsDebugEnabled())
                     {
                         Log.Debug($"Splits are ready in {_splitsReadyTimer.ElapsedMilliseconds} milliseconds");
                     }
@@ -67,7 +69,7 @@ namespace Splitio.Services.Client.Classes
 
             if (countDown.IsSet)
             {
-                if (Log.IsDebugEnabled)
+                if (Log.IsDebugEnabled())
                 {
                     Log.Debug(segmentName + " segment is ready");
                 }
@@ -89,7 +91,7 @@ namespace Splitio.Services.Client.Classes
             try
             {
                 segmentsAreReady.Add(segmentName, new CountdownEvent(1));
-                if (Log.IsDebugEnabled)
+                if (Log.IsDebugEnabled())
                 {
                     Log.Debug("Registered segment: " + segmentName);
                 }
@@ -131,7 +133,7 @@ namespace Splitio.Services.Client.Classes
             }
 
             _segmentsReadyTimer.Stop();
-            if (Log.IsDebugEnabled)
+            if (Log.IsDebugEnabled())
             {
                 Log.Debug($"Segments are ready in {_segmentsReadyTimer.ElapsedMilliseconds} milliseconds");
             }

--- a/src/Splitio-net-core/Services/Cache/Classes/InMemorySegmentCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Classes/InMemorySegmentCache.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -8,7 +9,7 @@ namespace Splitio.Services.Cache.Classes
 {
     public class InMemorySegmentCache : ISegmentCache
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(InMemorySegmentCache));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(InMemorySegmentCache));
 
         private ConcurrentDictionary<string, Segment> segments;
 

--- a/src/Splitio-net-core/Services/Cache/Classes/InMemorySplitCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Classes/InMemorySplitCache.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +10,7 @@ namespace Splitio.Services.Cache.Classes
 {
     public class InMemorySplitCache : ISplitCache
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(InMemorySplitCache));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(InMemorySplitCache));
 
         private ConcurrentDictionary<string, ParsedSplit> _splits;
         private ConcurrentDictionary<string, int> _trafficTypes;

--- a/src/Splitio-net-core/Services/Client/Classes/JSONFileClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/JSONFileClient.cs
@@ -1,8 +1,8 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Classes;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Parsing.Classes;
 using Splitio.Services.SegmentFetcher.Classes;
 using Splitio.Services.Shared.Classes;
@@ -15,17 +15,15 @@ namespace Splitio.Services.Client.Classes
 {
     public class JSONFileClient : SplitClient
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(JSONFileClient));
-
         public JSONFileClient(string splitsFilePath,
             string segmentsFilePath,
-            ILog log,
+            ISplitLogger log = null,
             ISegmentCache segmentCacheInstance = null,
             ISplitCache splitCacheInstance = null,
             IListener<KeyImpression> treatmentLogInstance = null,
             bool isLabelsEnabled = true,
             IListener<WrappedEvent> _eventListener = null,
-            ITrafficTypeValidator trafficTypeValidator = null) : base(log)
+            ITrafficTypeValidator trafficTypeValidator = null) : base(GetLogger(log))
         {
             segmentCache = segmentCacheInstance ?? new InMemorySegmentCache(new ConcurrentDictionary<string, Segment>());
             var segmentFetcher = new JSONFileSegmentFetcher(segmentsFilePath, segmentCache);            
@@ -77,6 +75,13 @@ namespace Splitio.Services.Client.Classes
                 segmentCache.Clear();
                 base.Destroy();
             }
+        }
+        #endregion
+
+        #region Private Methods
+        private static ISplitLogger GetLogger(ISplitLogger splitLogger = null)
+        {
+            return splitLogger ?? WrapperAdapter.GetLogger(typeof(JSONFileClient));
         }
         #endregion
     }

--- a/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
@@ -1,11 +1,11 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
+﻿using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Client.Interfaces;
 using Splitio.Services.Evaluator;
 using Splitio.Services.InputValidation.Classes;
 using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Metrics.Interfaces;
 using Splitio.Services.Parsing.Interfaces;
 using Splitio.Services.Shared.Classes;
@@ -18,7 +18,7 @@ namespace Splitio.Services.Client.Classes
 {
     public abstract class SplitClient : ISplitClient
     {
-        protected readonly ILog _log;
+        protected readonly ISplitLogger _log;
         protected readonly IKeyValidator _keyValidator;
         protected readonly ISplitNameValidator _splitNameValidator;
         protected readonly IEventTypeValidator _eventTypeValidator;
@@ -50,14 +50,14 @@ namespace Splitio.Services.Client.Classes
         protected ISplitParser _splitParser;
         protected IEvaluator _evaluator;
 
-        public SplitClient(ILog log)
+        public SplitClient(ISplitLogger log)
         {
             _log = log;
-            _keyValidator = new KeyValidator(_log);
-            _splitNameValidator = new SplitNameValidator(_log);
-            _eventTypeValidator = new EventTypeValidator(_log);
-            _eventPropertiesValidator = new EventPropertiesValidator(_log);
-            _factoryInstantiationsService = FactoryInstantiationsService.Instance(log);
+            _keyValidator = new KeyValidator();
+            _splitNameValidator = new SplitNameValidator();
+            _eventTypeValidator = new EventTypeValidator();
+            _eventPropertiesValidator = new EventPropertiesValidator();
+            _factoryInstantiationsService = FactoryInstantiationsService.Instance();
             _wrapperAdapter = new WrapperAdapter();
         }
 
@@ -216,7 +216,7 @@ namespace Splitio.Services.Client.Classes
             return true;
         }
 
-        protected void BuildEvaluator(ILog log = null)
+        protected void BuildEvaluator(ISplitLogger log = null)
         {
             _evaluator = new Evaluator.Evaluator(splitCache, _splitParser, log: log);
         }

--- a/src/Splitio-net-core/Services/Client/Classes/SplitFactory.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitFactory.cs
@@ -1,7 +1,6 @@
 using Splitio.Services.Client.Interfaces;
 using Splitio.Services.InputValidation.Classes;
 using Splitio.Services.InputValidation.Interfaces;
-using Splitio.Services.Logger;
 using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
 using System;
@@ -12,7 +11,6 @@ namespace Splitio.Services.Client.Classes
     public class SplitFactory
     {
         private readonly IApiKeyValidator _apiKeyValidator;
-        private readonly ISplitLogger _log;
         private readonly IFactoryInstantiationsService _factoryInstantiationsService;
         private readonly string _apiKey;
 
@@ -26,7 +24,6 @@ namespace Splitio.Services.Client.Classes
             _apiKey = apiKey;
             _options = options;
 
-            _log = WrapperAdapter.GetLogger(typeof(SplitClient));
             _apiKeyValidator = new ApiKeyValidator();
             _factoryInstantiationsService = FactoryInstantiationsService.Instance();
         }

--- a/src/Splitio-net-core/Services/Client/Classes/SplitFactory.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitFactory.cs
@@ -70,7 +70,7 @@ namespace Splitio.Services.Client.Classes
                                 throw new Exception("Redis Host and Port should be set to initialize Split SDK in Redis Mode.");
                             }
 
-                            var redisAssembly = Assembly.Load(new AssemblyName("Splitio-net-core.Redis"));
+                            var redisAssembly = Assembly.Load(new AssemblyName("Splitio.Redis"));
                             var redisType = redisAssembly.GetType("Splitio.Redis.Services.Client.Classes.RedisClient");
 
                             _client = (ISplitClient)Activator.CreateInstance(redisType, new object[] { _options, _apiKey, null });

--- a/src/Splitio-net-core/Services/Client/Classes/SplitManager.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitManager.cs
@@ -1,9 +1,10 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Client.Interfaces;
 using Splitio.Services.InputValidation.Classes;
 using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,17 +13,17 @@ namespace Splitio.Services.Client.Classes
 {
     public class SplitManager : ISplitManager
     {
-        private readonly ILog _log;
+        private readonly ISplitLogger _log;
         private readonly ISplitCache _splitCache;
         private readonly ISplitNameValidator _splitNameValidator;
         private readonly IBlockUntilReadyService _blockUntilReadyService;
 
         public SplitManager(ISplitCache splitCache,
             IBlockUntilReadyService blockUntilReadyService,
-            ILog log = null)
+            ISplitLogger log = null)
         {
             _splitCache = splitCache;
-            _log = log ?? LogManager.GetLogger(typeof(SplitManager));
+            _log = log ?? WrapperAdapter.GetLogger(typeof(SplitManager));
             _splitNameValidator = new SplitNameValidator(_log);
             _blockUntilReadyService = blockUntilReadyService;
         }

--- a/src/Splitio-net-core/Services/Evaluator/Evaluator.cs
+++ b/src/Splitio-net-core/Services/Evaluator/Evaluator.cs
@@ -1,8 +1,9 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.EngineEvaluator;
+using Splitio.Services.Logger;
 using Splitio.Services.Parsing.Interfaces;
+using Splitio.Services.Shared.Classes;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -14,19 +15,19 @@ namespace Splitio.Services.Evaluator
         protected const string Control = "control";
 
         private readonly ISplitter _splitter;
-        private readonly ILog _log;        
+        private readonly ISplitLogger _log;        
         private readonly ISplitParser _splitParser;
         private readonly ISplitCache _splitCache;
 
         public Evaluator(ISplitCache splitCache,
             ISplitParser splitParser,
             ISplitter splitter = null,
-            ILog log = null)
+            ISplitLogger log = null)
         {
             _splitCache = splitCache;
             _splitParser = splitParser;
             _splitter = splitter ?? new Splitter();
-            _log = log ?? LogManager.GetLogger(typeof(Evaluator));
+            _log = log ?? WrapperAdapter.GetLogger(typeof(Evaluator));
         }
 
         #region Public Method

--- a/src/Splitio-net-core/Services/Events/Classes/EventSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Events/Classes/EventSdkApiClient.cs
@@ -1,8 +1,9 @@
-﻿using Common.Logging;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Events.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System.Collections.Generic;
 using System.Net;
 
@@ -12,7 +13,7 @@ namespace Splitio.Services.Events.Classes
     {
         private const string EventsUrlTemplate = "/api/events/bulk";
         
-        private static readonly ILog Log = LogManager.GetLogger(typeof(EventSdkApiClient));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(EventSdkApiClient));
 
         public EventSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) 
             : base(header, baseUrl, connectionTimeOut, readTimeout)

--- a/src/Splitio-net-core/Services/Events/Classes/SelfUpdatingEventLog.cs
+++ b/src/Splitio-net-core/Services/Events/Classes/SelfUpdatingEventLog.cs
@@ -1,7 +1,7 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
+﻿using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Events.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
 using System;
@@ -23,7 +23,7 @@ namespace Splitio.Services.Events.Classes
         private ISimpleProducerCache<WrappedEvent> wrappedEventsCache;
         private CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-        protected static readonly ILog Logger = LogManager.GetLogger(typeof(SelfUpdatingEventLog));
+        protected static readonly ISplitLogger Logger = WrapperAdapter.GetLogger(typeof(SelfUpdatingEventLog));
 
         public SelfUpdatingEventLog(IEventSdkApiClient apiClient, int firstPushWindow, int interval, ISimpleCache<WrappedEvent> eventsCache, int maximumNumberOfKeysToCache = -1)
         {

--- a/src/Splitio-net-core/Services/Impressions/Classes/SelfUpdatingTreatmentLog.cs
+++ b/src/Splitio-net-core/Services/Impressions/Classes/SelfUpdatingTreatmentLog.cs
@@ -1,7 +1,7 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
+﻿using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Impressions.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
 using System;
@@ -16,7 +16,7 @@ namespace Splitio.Services.Impressions.Classes
         private ISimpleProducerCache<KeyImpression> impressionsCache;
         private CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-        protected static readonly ILog Logger = LogManager.GetLogger(typeof(SelfUpdatingTreatmentLog));
+        protected static readonly ISplitLogger Logger = WrapperAdapter.GetLogger(typeof(SelfUpdatingTreatmentLog));
 
         public SelfUpdatingTreatmentLog(ITreatmentSdkApiClient apiClient, int interval, ISimpleCache<KeyImpression> impressionsCache, int maximumNumberOfKeysToCache = -1)
         {

--- a/src/Splitio-net-core/Services/Impressions/Classes/TreatmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Impressions/Classes/TreatmentSdkApiClient.cs
@@ -1,8 +1,9 @@
-﻿using Common.Logging;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Impressions.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -13,7 +14,7 @@ namespace Splitio.Services.Impressions.Classes
     {
         private const string TestImpressionsUrlTemplate = "/api/testImpressions/bulk";
         
-        private static readonly ILog Log = LogManager.GetLogger(typeof(TreatmentSdkApiClient));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(TreatmentSdkApiClient));
 
         public TreatmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) 
             : base(header, baseUrl, connectionTimeOut, readTimeout)
@@ -37,6 +38,7 @@ namespace Splitio.Services.Impressions.Classes
                 impressions
                 .GroupBy(item => item.feature)
                 .Select(group => new { testName = group.Key, keyImpressions = group.Select(x => new { keyName = x.keyName, treatment = x.treatment, time = x.time, changeNumber = x.changeNumber, label = x.label, bucketingKey = x.bucketingKey }) });
+
             return JsonConvert.SerializeObject(impressionsPerFeature);
         }
     }

--- a/src/Splitio-net-core/Services/InputValidation/Classes/ApiKeyValidator.cs
+++ b/src/Splitio-net-core/Services/InputValidation/Classes/ApiKeyValidator.cs
@@ -1,15 +1,16 @@
-﻿using Common.Logging;
-using Splitio.Services.InputValidation.Interfaces;
+﻿using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 
 namespace Splitio.Services.InputValidation.Classes
 {
     public class ApiKeyValidator : IApiKeyValidator
     {
-        protected readonly ILog _log;
+        protected readonly ISplitLogger _log;
 
-        public ApiKeyValidator(ILog log)
+        public ApiKeyValidator(ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(ApiKeyValidator));
         }
 
         public void Validate(string apiKey)

--- a/src/Splitio-net-core/Services/InputValidation/Classes/EventPropertiesValidator.cs
+++ b/src/Splitio-net-core/Services/InputValidation/Classes/EventPropertiesValidator.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System;
 using System.Collections.Generic;
 
@@ -9,11 +10,11 @@ namespace Splitio.Services.InputValidation.Classes
     public class EventPropertiesValidator : IEventPropertiesValidator
     {
         private const int MAX_PROPERTIES_LENGTH_BYTES = 32 * 1024;
-        protected readonly ILog _log;
+        protected readonly ISplitLogger _log;
 
-        public EventPropertiesValidator(ILog log)
+        public EventPropertiesValidator(ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(EventPropertiesValidator));
         }
 
         public EventValidatorResult IsValid(Dictionary<string, object> properties)

--- a/src/Splitio-net-core/Services/InputValidation/Classes/EventTypeValidator.cs
+++ b/src/Splitio-net-core/Services/InputValidation/Classes/EventTypeValidator.cs
@@ -1,5 +1,6 @@
-﻿using Common.Logging;
-using Splitio.Services.InputValidation.Interfaces;
+﻿using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System.Text.RegularExpressions;
 
 namespace Splitio.Services.InputValidation.Classes
@@ -8,11 +9,11 @@ namespace Splitio.Services.InputValidation.Classes
     {
         private const string REGEX = "^[a-zA-Z0-9][-_.:a-zA-Z0-9]{0,79}$";
 
-        protected readonly ILog _log;
+        protected readonly ISplitLogger _log;
 
-        public EventTypeValidator(ILog log)
+        public EventTypeValidator(ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(EventTypeValidator));
         }
 
         public bool IsValid(string eventType, string method)

--- a/src/Splitio-net-core/Services/InputValidation/Classes/KeyValidator.cs
+++ b/src/Splitio-net-core/Services/InputValidation/Classes/KeyValidator.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 
 namespace Splitio.Services.InputValidation.Classes
 {
@@ -8,11 +9,11 @@ namespace Splitio.Services.InputValidation.Classes
     {
         private const int KEY_MAX_LENGTH = 250;
 
-        protected readonly ILog _log;
+        protected readonly ISplitLogger _log;
 
-        public KeyValidator(ILog log)
+        public KeyValidator(ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(KeyValidator));
         }
 
         public bool IsValid(Key key, string method)

--- a/src/Splitio-net-core/Services/InputValidation/Classes/SplitNameValidator.cs
+++ b/src/Splitio-net-core/Services/InputValidation/Classes/SplitNameValidator.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,11 +11,11 @@ namespace Splitio.Services.InputValidation.Classes
     {
         private const string WHITESPACE = " ";
 
-        protected readonly ILog _log;
+        protected readonly ISplitLogger _log;
 
-        public SplitNameValidator(ILog log)
+        public SplitNameValidator(ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(SplitNameValidator));
         }
 
         public List<string> SplitNamesAreValid(List<string> splitNames, string method)

--- a/src/Splitio-net-core/Services/InputValidation/Classes/TrafficTypeValidator.cs
+++ b/src/Splitio-net-core/Services/InputValidation/Classes/TrafficTypeValidator.cs
@@ -1,19 +1,20 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.InputValidation.Interfaces;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System.Linq;
 
 namespace Splitio.Services.InputValidation.Classes
 {
     public class TrafficTypeValidator : ITrafficTypeValidator
     {
-        private readonly ILog _log;
+        private readonly ISplitLogger _log;
         private readonly ISplitCache _splitCache;
 
-        public TrafficTypeValidator(ILog log, ISplitCache splitCache)
+        public TrafficTypeValidator(ISplitCache splitCache, ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(TrafficTypeValidator));
             _splitCache = splitCache;
         }
 

--- a/src/Splitio-net-core/Services/Logger/CommonLogging.cs
+++ b/src/Splitio-net-core/Services/Logger/CommonLogging.cs
@@ -1,0 +1,77 @@
+﻿#if NET40 || NET45
+using Common.Logging;
+using System; 
+
+namespace Splitio.Services.Logger
+{
+    public class CommonLogging : ISplitLogger
+    {
+        private ILog _logger;
+
+        public CommonLogging(Type type)
+        {
+            _logger = LogManager.GetLogger(type);
+        }
+
+        public CommonLogging(string type)
+        {
+            _logger = LogManager.GetLogger(type);
+        }
+
+        public void Debug(string message, Exception exception)
+        {
+            _logger.Debug(message, exception);
+        }
+
+        public void Debug(string message)
+        {
+            _logger.Debug(message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            _logger.Error(message, exception);
+        }
+
+        public void Error(string message)
+        {
+            _logger.Error(message);
+        }
+
+        public void Info(string message, Exception exception)
+        {
+            _logger.Info(message, exception);
+        }
+
+        public void Info(string message)
+        {
+            _logger.Info(message);
+        }
+
+        public bool IsDebugEnabled()
+        {
+            return _logger.IsDebugEnabled;
+        }
+
+        public void Trace(string message, Exception exception)
+        {
+            _logger.Trace(message, exception);
+        }
+
+        public void Trace(string message)
+        {
+            _logger.Trace(message);
+        }
+
+        public void Warn(string message, Exception exception)
+        {
+            _logger.Warn(message, exception);
+        }
+
+        public void Warn(string message)
+        {
+            _logger.Warn(message);
+        }
+    }
+}
+#endif

--- a/src/Splitio-net-core/Services/Logger/CommonLogging.cs
+++ b/src/Splitio-net-core/Services/Logger/CommonLogging.cs
@@ -47,12 +47,7 @@ namespace Splitio.Services.Logger
         {
             _logger.Info(message);
         }
-
-        public bool IsDebugEnabled()
-        {
-            return _logger.IsDebugEnabled;
-        }
-
+        
         public void Trace(string message, Exception exception)
         {
             _logger.Trace(message, exception);
@@ -72,6 +67,8 @@ namespace Splitio.Services.Logger
         {
             _logger.Warn(message);
         }
+
+        public bool IsDebugEnabled => _logger.IsDebugEnabled;
     }
 }
 #endif

--- a/src/Splitio-net-core/Services/Logger/ISplitLogger.cs
+++ b/src/Splitio-net-core/Services/Logger/ISplitLogger.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Splitio.Services.Logger
+{
+    public interface ISplitLogger
+    {
+        void Debug(string message, Exception exception);
+        void Debug(string message);
+        void Error(string message, Exception exception);
+        void Error(string message);
+        void Info(string message, Exception exception);
+        void Info(string message);
+        void Trace(string message, Exception exception);
+        void Trace(string message);
+        void Warn(string message, Exception exception);
+        void Warn(string message);
+
+        bool IsDebugEnabled();
+    }
+}

--- a/src/Splitio-net-core/Services/Logger/ISplitLogger.cs
+++ b/src/Splitio-net-core/Services/Logger/ISplitLogger.cs
@@ -15,6 +15,6 @@ namespace Splitio.Services.Logger
         void Warn(string message, Exception exception);
         void Warn(string message);
 
-        bool IsDebugEnabled();
+        bool IsDebugEnabled { get; }
     }
 }

--- a/src/Splitio-net-core/Services/Logger/MicrosoftExtensionsLogging.cs
+++ b/src/Splitio-net-core/Services/Logger/MicrosoftExtensionsLogging.cs
@@ -6,12 +6,12 @@ namespace Splitio.Services.Logger
 {
     public class MicrosoftExtensionsLogging : ISplitLogger
     {
-        private const int DefaultLoggingEvent = 5000;
+        private const int DefaultLoggingEvent = 0;
 
-        private static readonly ILoggerFactory _loggerFactory = new LoggerFactory();
+        private static ILoggerFactory _loggerFactory => Extensions.GetLoggerFactory() ?? new LoggerFactory();
 
         private readonly ILogger _logger;
-
+        
         public MicrosoftExtensionsLogging(Type type)
         {
             _logger = _loggerFactory.CreateLogger(type);
@@ -75,6 +75,23 @@ namespace Splitio.Services.Logger
         public void Warn(string message)
         {
             _logger.LogWarning(message);
+        }
+    }
+
+    public static class Extensions
+    {
+        private static ILoggerFactory _loggerFactory;
+
+        public static ILoggerFactory AddSplitLogs(this ILoggerFactory factory)
+        {
+            _loggerFactory = factory;
+
+            return factory;
+        }
+
+        public static ILoggerFactory GetLoggerFactory()
+        {
+            return _loggerFactory;
         }
     }
 }

--- a/src/Splitio-net-core/Services/Logger/MicrosoftExtensionsLogging.cs
+++ b/src/Splitio-net-core/Services/Logger/MicrosoftExtensionsLogging.cs
@@ -1,0 +1,81 @@
+﻿# if NETSTANDARD
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Splitio.Services.Logger
+{
+    public class MicrosoftExtensionsLogging : ISplitLogger
+    {
+        private const int DefaultLoggingEvent = 5000;
+
+        private static readonly ILoggerFactory _loggerFactory = new LoggerFactory();
+
+        private readonly ILogger _logger;
+
+        public MicrosoftExtensionsLogging(Type type)
+        {
+            _logger = _loggerFactory.CreateLogger(type);
+        }
+
+        public MicrosoftExtensionsLogging(string type)
+        {
+            _logger = _loggerFactory.CreateLogger(type);
+        }
+
+        public void Debug(string message, Exception exception)
+        {
+            _logger.LogDebug(DefaultLoggingEvent, exception, message);
+        }
+
+        public void Debug(string message)
+        {
+            _logger.LogDebug(message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            _logger.LogError(DefaultLoggingEvent, exception, message);
+        }
+
+        public void Error(string message)
+        {
+            _logger.LogError(message);
+        }        
+
+        public void Info(string message, Exception exception)
+        {
+            _logger.LogInformation(DefaultLoggingEvent, exception, message);
+        }
+
+        public void Info(string message)
+        {
+            _logger.LogInformation(message);
+        }
+
+        public bool IsDebugEnabled()
+        {
+            return _logger.IsEnabled(LogLevel.Debug);
+        }
+
+        public void Trace(string message, Exception exception)
+        {
+            _logger.LogTrace(DefaultLoggingEvent, exception, message);
+        }
+
+        public void Trace(string message)
+        {
+            _logger.LogTrace(message);
+        }
+
+        public void Warn(string message, Exception exception)
+        {
+            _logger.LogWarning(DefaultLoggingEvent, exception, message);
+        }
+
+        public void Warn(string message)
+        {
+            _logger.LogWarning(message);
+        }
+    }
+}
+#endif

--- a/src/Splitio-net-core/Services/Logger/MicrosoftExtensionsLogging.cs
+++ b/src/Splitio-net-core/Services/Logger/MicrosoftExtensionsLogging.cs
@@ -8,7 +8,7 @@ namespace Splitio.Services.Logger
     {
         private const int DefaultLoggingEvent = 0;
 
-        private static ILoggerFactory _loggerFactory => Extensions.GetLoggerFactory() ?? new LoggerFactory();
+        private static ILoggerFactory _loggerFactory => SplitLoggerFactoryExtensions.GetLoggerFactory() ?? new LoggerFactory();
 
         private readonly ILogger _logger;
         
@@ -75,23 +75,6 @@ namespace Splitio.Services.Logger
         public void Warn(string message)
         {
             _logger.LogWarning(message);
-        }
-    }
-
-    public static class Extensions
-    {
-        private static ILoggerFactory _loggerFactory;
-
-        public static ILoggerFactory AddSplitLogs(this ILoggerFactory factory)
-        {
-            _loggerFactory = factory;
-
-            return factory;
-        }
-
-        public static ILoggerFactory GetLoggerFactory()
-        {
-            return _loggerFactory;
         }
     }
 }

--- a/src/Splitio-net-core/Services/Logger/MicrosoftExtensionsLogging.cs
+++ b/src/Splitio-net-core/Services/Logger/MicrosoftExtensionsLogging.cs
@@ -7,11 +7,11 @@ namespace Splitio.Services.Logger
     public class MicrosoftExtensionsLogging : ISplitLogger
     {
         private const int DefaultLoggingEvent = 0;
-
+        
         private static ILoggerFactory _loggerFactory => SplitLoggerFactoryExtensions.GetLoggerFactory() ?? new LoggerFactory();
 
         private readonly ILogger _logger;
-        
+
         public MicrosoftExtensionsLogging(Type type)
         {
             _logger = _loggerFactory.CreateLogger(type);
@@ -51,12 +51,7 @@ namespace Splitio.Services.Logger
         {
             _logger.LogInformation(message);
         }
-
-        public bool IsDebugEnabled()
-        {
-            return _logger.IsEnabled(LogLevel.Debug);
-        }
-
+        
         public void Trace(string message, Exception exception)
         {
             _logger.LogTrace(DefaultLoggingEvent, exception, message);
@@ -76,6 +71,8 @@ namespace Splitio.Services.Logger
         {
             _logger.LogWarning(message);
         }
+
+        public bool IsDebugEnabled => _logger.IsEnabled(LogLevel.Debug);
     }
 }
 #endif

--- a/src/Splitio-net-core/Services/Logger/SplitLoggerFactoryExtensions.cs
+++ b/src/Splitio-net-core/Services/Logger/SplitLoggerFactoryExtensions.cs
@@ -1,0 +1,21 @@
+﻿# if NETSTANDARD
+namespace Microsoft.Extensions.Logging
+{
+    public static class SplitLoggerFactoryExtensions
+    {
+        private static ILoggerFactory _loggerFactory;
+
+        public static ILoggerFactory AddSplitLogs(this ILoggerFactory factory)
+        {
+            _loggerFactory = factory;
+
+            return factory;
+        }
+
+        public static ILoggerFactory GetLoggerFactory()
+        {
+            return _loggerFactory;
+        }
+    }
+}
+#endif

--- a/src/Splitio-net-core/Services/Metrics/Classes/AsyncMetricsLog.cs
+++ b/src/Splitio-net-core/Services/Metrics/Classes/AsyncMetricsLog.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Services.Cache.Interfaces;
+﻿using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Metrics.Interfaces;
+using Splitio.Services.Shared.Classes;
 using System;
 using System.Threading.Tasks;
 
@@ -10,7 +11,7 @@ namespace Splitio.Services.Metrics.Classes
     {
         IMetricsLog worker;
 
-        protected static readonly ILog Logger = LogManager.GetLogger(typeof(AsyncMetricsLog));
+        protected static readonly ISplitLogger Logger = WrapperAdapter.GetLogger(typeof(AsyncMetricsLog));
 
         public AsyncMetricsLog(IMetricsSdkApiClient apiClient, IMetricsCache metricsCache, int maxCountCalls = -1, int maxTimeBetweenCalls = -1)
         {

--- a/src/Splitio-net-core/Services/Metrics/Classes/InMemoryMetricsLog.cs
+++ b/src/Splitio-net-core/Services/Metrics/Classes/InMemoryMetricsLog.cs
@@ -1,7 +1,8 @@
-﻿using Common.Logging;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Metrics.Interfaces;
+using Splitio.Services.Shared.Classes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,13 +22,13 @@ namespace Splitio.Services.Metrics.Classes
         private object countMetricsLockObject = new Object();
         private object timeMetricsLockObject = new Object();
         private object gaugeMetricsLockObject = new Object();
-        private Boolean sendingCountMetrics = false;
-        private Boolean sendingTimeMetrics = false;
-        private Boolean sendingGaugeMetrics = false;
+        private bool sendingCountMetrics = false;
+        private bool sendingTimeMetrics = false;
+        private bool sendingGaugeMetrics = false;
         private int gaugeCallCount = 0;
 
 
-        protected static readonly ILog Logger = LogManager.GetLogger(typeof(InMemoryMetricsLog));
+        protected static readonly ISplitLogger Logger = WrapperAdapter.GetLogger(typeof(InMemoryMetricsLog));
 
         public InMemoryMetricsLog(IMetricsSdkApiClient apiClient, IMetricsCache metricsCache, int maxCountCalls = 1000, int maxTimeBetweenCalls = 60)
         {

--- a/src/Splitio-net-core/Services/Metrics/Classes/MetricsSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/Metrics/Classes/MetricsSdkApiClient.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
+﻿using Splitio.CommonLibraries;
+using Splitio.Services.Logger;
 using Splitio.Services.Metrics.Interfaces;
+using Splitio.Services.Shared.Classes;
 using System.Net;
 
 namespace Splitio.Services.Metrics.Classes
@@ -9,7 +10,7 @@ namespace Splitio.Services.Metrics.Classes
     {
         private const string MetricsUrlTemplate = "/api/metrics/{endpoint}";
 
-        private static readonly ILog Log = LogManager.GetLogger(typeof(MetricsSdkApiClient));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(MetricsSdkApiClient));
 
         public MetricsSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) 
             : base(header, baseUrl, connectionTimeOut, readTimeout)

--- a/src/Splitio-net-core/Services/Parsing/Classes/SplitParser.cs
+++ b/src/Splitio-net-core/Services/Parsing/Classes/SplitParser.cs
@@ -1,8 +1,9 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Parsing.Classes;
 using Splitio.Services.Parsing.Interfaces;
+using Splitio.Services.Shared.Classes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,7 @@ namespace Splitio.Services.Parsing
 {
     public abstract class SplitParser : ISplitParser
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SplitParser));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SplitParser));
         protected ISegmentCache segmentsCache;
 
         public ParsedSplit Parse(Split split)

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
+using Splitio.Services.Logger;
 using Splitio.Services.SegmentFetcher.Interfaces;
+using Splitio.Services.Shared.Classes;
 using System;
 using System.Threading.Tasks;
 
@@ -9,7 +10,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
     public abstract class SegmentChangeFetcher: ISegmentChangeFetcher
     {
         private SegmentChange segmentChange;
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentChangeFetcher));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SegmentChangeFetcher));
 
         protected abstract Task<SegmentChange> FetchFromBackend(string name, long since);
 

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
+﻿using Splitio.CommonLibraries;
+using Splitio.Services.Logger;
 using Splitio.Services.Metrics.Interfaces;
+using Splitio.Services.Shared.Classes;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
 using System.Diagnostics;
@@ -17,7 +18,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
         private const string SegmentFetcherStatus = "segmentChangeFetcher.status.{0}";
         private const string SegmentFetcherException = "segmentChangeFetcher.exception";
 
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentSdkApiClient));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SegmentSdkApiClient));
 
         public SegmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
 
@@ -38,7 +39,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                         metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
                     }
 
-                    if (Log.IsDebugEnabled)
+                    if (Log.IsDebugEnabled())
                     {
                         Log.Debug($"FetchSegmentChanges with name '{name}' took {clock.ElapsedMilliseconds} milliseconds using uri '{requestUri}'");
                     }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -39,7 +39,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                         metricsLog.Count(string.Format(SegmentFetcherStatus, response.statusCode), 1);
                     }
 
-                    if (Log.IsDebugEnabled())
+                    if (Log.IsDebugEnabled)
                     {
                         Log.Debug($"FetchSegmentChanges with name '{name}' took {clock.ElapsedMilliseconds} milliseconds using uri '{requestUri}'");
                     }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -6,7 +7,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 {
     public class SegmentTaskWorker
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentTaskWorker));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SegmentTaskWorker));
 
         private readonly int numberOfParallelTasks;
         private int counter;
@@ -42,7 +43,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                     //Wait indefinitely until a segment is queued
                     if (SegmentTaskQueue.segmentsQueue.TryTake(out segment, -1))
                     {
-                        if (Log.IsDebugEnabled)
+                        if (Log.IsDebugEnabled())
                         {
                             Log.Debug(string.Format("Segment dequeued: {0}", segment.name));
                         }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
@@ -43,7 +43,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                     //Wait indefinitely until a segment is queued
                     if (SegmentTaskQueue.segmentsQueue.TryTake(out segment, -1))
                     {
-                        if (Log.IsDebugEnabled())
+                        if (Log.IsDebugEnabled)
                         {
                             Log.Debug(string.Format("Segment dequeued: {0}", segment.name));
                         }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
@@ -51,14 +51,14 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
                         if (response.added.Count() > 0)
                         {
-                            if (Log.IsDebugEnabled())
+                            if (Log.IsDebugEnabled)
                             {
                                 Log.Debug(string.Format("Segment {0} - Added : {1}", name, string.Join(" - ", response.added)));
                             }
                         }
                         if (response.removed.Count() > 0)
                         {
-                            if (Log.IsDebugEnabled())
+                            if (Log.IsDebugEnabled)
                             {
                                 Log.Debug(string.Format("Segment {0} - Removed : {1}", name, string.Join(" - ", response.removed)));
                             }
@@ -73,7 +73,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                 }
                 finally
                 {
-                    if (Log.IsDebugEnabled())
+                    if (Log.IsDebugEnabled)
                     {
                         Log.Debug(string.Format("segment {0} fetch before: {1}, after: {2}", name, changeNumber, segmentCache.GetChangeNumber(name)));
                     }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.Services.Cache.Interfaces;
+﻿using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.SegmentFetcher.Interfaces;
+using Splitio.Services.Shared.Classes;
 using System;
 using System.Linq;
 
@@ -8,7 +9,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 {
     public class SelfRefreshingSegment
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SelfRefreshingSegment));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SelfRefreshingSegment));
 
         public readonly string name;
         private readonly IReadinessGatesCache gates;
@@ -50,14 +51,14 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
                         if (response.added.Count() > 0)
                         {
-                            if (Log.IsDebugEnabled)
+                            if (Log.IsDebugEnabled())
                             {
                                 Log.Debug(string.Format("Segment {0} - Added : {1}", name, string.Join(" - ", response.added)));
                             }
                         }
                         if (response.removed.Count() > 0)
                         {
-                            if (Log.IsDebugEnabled)
+                            if (Log.IsDebugEnabled())
                             {
                                 Log.Debug(string.Format("Segment {0} - Removed : {1}", name, string.Join(" - ", response.removed)));
                             }
@@ -72,7 +73,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                 }
                 finally
                 {
-                    if (Log.IsDebugEnabled)
+                    if (Log.IsDebugEnabled())
                     {
                         Log.Debug(string.Format("segment {0} fetch before: {1}, after: {2}", name, changeNumber, segmentCache.GetChangeNumber(name)));
                     }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
@@ -69,7 +69,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                 segment = new SelfRefreshingSegment(name, segmentChangeFetcher, gates, segmentCache);
                 segments.TryAdd(name, segment);
                 SegmentTaskQueue.segmentsQueue.TryAdd(segment);
-                if (Log.IsDebugEnabled())
+                if (Log.IsDebugEnabled)
                 {
                     Log.Debug(string.Format("Segment queued: {0}", segment.name));
                 }
@@ -81,7 +81,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
             foreach (SelfRefreshingSegment segment in segments.Values)
             {
                 SegmentTaskQueue.segmentsQueue.TryAdd(segment);
-                if (Log.IsDebugEnabled())
+                if (Log.IsDebugEnabled)
                 {
                     Log.Debug(string.Format("Segment queued: {0}", segment.name));
                 }

--- a/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
+++ b/src/Splitio-net-core/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
@@ -1,6 +1,6 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
+﻿using Splitio.CommonLibraries;
 using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using Splitio.Services.Shared.Classes;
 using Splitio.Services.Shared.Interfaces;
@@ -12,7 +12,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 {
     public class SelfRefreshingSegmentFetcher : SegmentFetcher
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SelfRefreshingSegmentFetcher));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SelfRefreshingSegmentFetcher));
 
         private readonly ISegmentChangeFetcher segmentChangeFetcher;
         private readonly ConcurrentDictionary<string, SelfRefreshingSegment> segments;
@@ -69,7 +69,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                 segment = new SelfRefreshingSegment(name, segmentChangeFetcher, gates, segmentCache);
                 segments.TryAdd(name, segment);
                 SegmentTaskQueue.segmentsQueue.TryAdd(segment);
-                if (Log.IsDebugEnabled)
+                if (Log.IsDebugEnabled())
                 {
                     Log.Debug(string.Format("Segment queued: {0}", segment.name));
                 }
@@ -81,7 +81,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
             foreach (SelfRefreshingSegment segment in segments.Values)
             {
                 SegmentTaskQueue.segmentsQueue.TryAdd(segment);
-                if (Log.IsDebugEnabled)
+                if (Log.IsDebugEnabled())
                 {
                     Log.Debug(string.Format("Segment queued: {0}", segment.name));
                 }

--- a/src/Splitio-net-core/Services/Shared/Classes/AbstractLocalhostFileService.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/AbstractLocalhostFileService.cs
@@ -1,5 +1,5 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
+using Splitio.Services.Logger;
 using Splitio.Services.Parsing;
 using Splitio.Services.Shared.Interfaces;
 using System.Collections.Concurrent;
@@ -11,7 +11,7 @@ namespace Splitio.Services.Shared.Classes
     {
         protected const string Control = "control";
 
-        protected ILog _log;
+        protected ISplitLogger _log;
 
         public abstract ConcurrentDictionary<string, ParsedSplit> ParseSplitFile(string filePath);
 

--- a/src/Splitio-net-core/Services/Shared/Classes/AsynchronousListener.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/AsynchronousListener.cs
@@ -1,4 +1,4 @@
-﻿using Common.Logging;
+﻿using Splitio.Services.Logger;
 using Splitio.Services.Shared.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -9,10 +9,10 @@ namespace Splitio.Services.Shared.Classes
 {
     public class AsynchronousListener<T> : IAsynchronousListener<T>
     {
-        protected readonly ILog _logger;
+        protected readonly ISplitLogger _logger;
         private List<IListener<T>> workers = new List<IListener<T>>();
 
-        public AsynchronousListener(ILog logger)
+        public AsynchronousListener(ISplitLogger logger)
         {
             _logger = logger;
         }

--- a/src/Splitio-net-core/Services/Shared/Classes/FactoryInstantiationsService.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/FactoryInstantiationsService.cs
@@ -1,4 +1,4 @@
-﻿using Common.Logging;
+﻿using Splitio.Services.Logger;
 using Splitio.Services.Shared.Interfaces;
 using System.Collections.Concurrent;
 
@@ -10,10 +10,10 @@ namespace Splitio.Services.Shared.Classes
         private static object _instanceLock = new object();
         private static object _lock = new object();
 
-        private ILog _log;
+        private ISplitLogger _log;
         private ConcurrentDictionary<string, int> _factoryInstantiations;
 
-        public static IFactoryInstantiationsService Instance(ILog log)
+        public static IFactoryInstantiationsService Instance(ISplitLogger log = null)
         {
             if (_instance == null)
             {
@@ -29,9 +29,9 @@ namespace Splitio.Services.Shared.Classes
             return _instance;
         }
 
-        private FactoryInstantiationsService(ILog log)
+        private FactoryInstantiationsService(ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(FactoryInstantiationsService));
             _factoryInstantiations = new ConcurrentDictionary<string, int>();
         }
 

--- a/src/Splitio-net-core/Services/Shared/Classes/LocalhostFileService.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/LocalhostFileService.cs
@@ -1,5 +1,5 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
+using Splitio.Services.Logger;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -9,9 +9,9 @@ namespace Splitio.Services.Shared.Classes
 {
     public class LocalhostFileService : AbstractLocalhostFileService
     {
-        public LocalhostFileService(ILog log)
+        public LocalhostFileService(ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(LocalhostFileService));
         }
 
         public override ConcurrentDictionary<string, ParsedSplit> ParseSplitFile(string filePath)

--- a/src/Splitio-net-core/Services/Shared/Classes/SelfRefreshingBlockUntilReadyService.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/SelfRefreshingBlockUntilReadyService.cs
@@ -1,6 +1,6 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.SegmentFetcher.Classes;
 using Splitio.Services.Shared.Interfaces;
 using Splitio.Services.SplitFetcher.Classes;
@@ -15,21 +15,21 @@ namespace Splitio.Services.Shared.Classes
         private readonly IReadinessGatesCache _gates;        
         private readonly IListener<KeyImpression> _treatmentLog;
         private readonly IListener<WrappedEvent> _eventLog;
-        private readonly ILog _log;
+        private readonly ISplitLogger _log;
 
         public SelfRefreshingBlockUntilReadyService(IReadinessGatesCache gates,
             SelfRefreshingSplitFetcher splitFetcher,
             SelfRefreshingSegmentFetcher selfRefreshingSegmentFetcher,
             IListener<KeyImpression> treatmentLog,
             IListener<WrappedEvent> eventLog, 
-            ILog log)
+            ISplitLogger log = null)
         {
             _gates = gates;
             _splitFetcher = splitFetcher;
             _selfRefreshingSegmentFetcher = selfRefreshingSegmentFetcher;
             _treatmentLog = treatmentLog;
             _eventLog = eventLog;
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(SelfRefreshingBlockUntilReadyService));
         }
 
         public void BlockUntilReady(int blockMilisecondsUntilReady)

--- a/src/Splitio-net-core/Services/Shared/Classes/WrapperAdapter.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/WrapperAdapter.cs
@@ -1,7 +1,6 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Client.Classes;
+using Splitio.Services.Logger;
 using Splitio.Services.Shared.Interfaces;
 using System;
 using System.Diagnostics;
@@ -15,7 +14,7 @@ namespace Splitio.Services.Shared.Classes
 {
     public class WrapperAdapter : IWrapperAdapter
     {
-        public ReadConfigData ReadConfig(ConfigurationOptions config, ILog log)
+        public ReadConfigData ReadConfig(ConfigurationOptions config, ISplitLogger log)
         {
             var data = new ReadConfigData();
 
@@ -78,6 +77,24 @@ namespace Splitio.Services.Shared.Classes
             return typeof(Split).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 #else
             return FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+#endif
+        }
+
+        public static ISplitLogger GetLogger(Type type)
+        {
+#if NETSTANDARD
+            return new MicrosoftExtensionsLogging(type);
+#else
+            return new CommonLogging(type);
+#endif
+        }
+
+        public static ISplitLogger GetLogger(string type)
+        {
+#if NETSTANDARD
+            return new MicrosoftExtensionsLogging(type);
+#else
+            return new CommonLogging(type);
 #endif
         }
 

--- a/src/Splitio-net-core/Services/Shared/Classes/YamlLocalhostFileService.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/YamlLocalhostFileService.cs
@@ -1,5 +1,5 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
+using Splitio.Services.Logger;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -10,9 +10,9 @@ namespace Splitio.Services.Shared.Classes
 {
     public class YamlLocalhostFileService : AbstractLocalhostFileService
     {
-        public YamlLocalhostFileService(ILog log)
+        public YamlLocalhostFileService(ISplitLogger log = null)
         {
-            _log = log;
+            _log = log ?? WrapperAdapter.GetLogger(typeof(YamlLocalhostFileService));
         }
 
         public override ConcurrentDictionary<string, ParsedSplit> ParseSplitFile(string filePath)

--- a/src/Splitio-net-core/Services/Shared/Interfaces/IWrapperAdapter.cs
+++ b/src/Splitio-net-core/Services/Shared/Interfaces/IWrapperAdapter.cs
@@ -1,13 +1,13 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
 using Splitio.Services.Client.Classes;
+using Splitio.Services.Logger;
 using System.Threading.Tasks;
 
 namespace Splitio.Services.Shared.Interfaces
 {
     public interface IWrapperAdapter
     {
-        ReadConfigData ReadConfig(ConfigurationOptions config, ILog log);
+        ReadConfigData ReadConfig(ConfigurationOptions config, ISplitLogger log);
         Task TaskDelay(int millisecondsDelay);
         Task<T> TaskFromResult<T>(T result);
     }

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
@@ -84,7 +84,7 @@ namespace Splitio.Services.SplitFetcher.Classes
             if (addedSplits.Count() > 0)
             {
                 var addedFeatureNames = addedSplits.Select(x => x.name).ToList();
-                if (Log.IsDebugEnabled())
+                if (Log.IsDebugEnabled)
                 {
                     Log.Debug(string.Format("Added features: {0}", string.Join(" - ", addedFeatureNames)));
                 }
@@ -92,7 +92,7 @@ namespace Splitio.Services.SplitFetcher.Classes
             if (removedSplits.Count() > 0)
             {
                 var removedFeatureNames = removedSplits.Select(x => x.name).ToList();
-                if (Log.IsDebugEnabled())
+                if (Log.IsDebugEnabled)
                 {
                     Log.Debug(string.Format("Deleted features: {0}", string.Join(" - ", removedFeatureNames)));
                 }
@@ -130,7 +130,7 @@ namespace Splitio.Services.SplitFetcher.Classes
                 }
                 finally
                 {
-                    if (Log.IsDebugEnabled())
+                    if (Log.IsDebugEnabled)
                     {
                         Log.Debug(string.Format("split fetch before: {0}, after: {1}", changeNumber, splitCache.GetChangeNumber()));
                     }

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
@@ -1,8 +1,9 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
+﻿using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
+using Splitio.Services.Logger;
 using Splitio.Services.Parsing.Interfaces;
+using Splitio.Services.Shared.Classes;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -14,13 +15,15 @@ namespace Splitio.Services.SplitFetcher.Classes
 {
     public class SelfRefreshingSplitFetcher
     {
-        protected ISplitCache splitCache;
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SelfRefreshingSplitFetcher));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SelfRefreshingSplitFetcher));
+
         private readonly ISplitChangeFetcher splitChangeFetcher;
         private readonly ISplitParser splitParser;
-        private readonly int interval;
-        private readonly CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
         private readonly IReadinessGatesCache gates;
+        private readonly CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
+        private readonly int interval;
+
+        protected ISplitCache splitCache;
 
         public SelfRefreshingSplitFetcher(ISplitChangeFetcher splitChangeFetcher,
             ISplitParser splitParser, 
@@ -81,7 +84,7 @@ namespace Splitio.Services.SplitFetcher.Classes
             if (addedSplits.Count() > 0)
             {
                 var addedFeatureNames = addedSplits.Select(x => x.name).ToList();
-                if (Log.IsDebugEnabled)
+                if (Log.IsDebugEnabled())
                 {
                     Log.Debug(string.Format("Added features: {0}", string.Join(" - ", addedFeatureNames)));
                 }
@@ -89,7 +92,7 @@ namespace Splitio.Services.SplitFetcher.Classes
             if (removedSplits.Count() > 0)
             {
                 var removedFeatureNames = removedSplits.Select(x => x.name).ToList();
-                if (Log.IsDebugEnabled)
+                if (Log.IsDebugEnabled())
                 {
                     Log.Debug(string.Format("Deleted features: {0}", string.Join(" - ", removedFeatureNames)));
                 }
@@ -127,7 +130,7 @@ namespace Splitio.Services.SplitFetcher.Classes
                 }
                 finally
                 {
-                    if (Log.IsDebugEnabled)
+                    if (Log.IsDebugEnabled())
                     {
                         Log.Debug(string.Format("split fetch before: {0}, after: {1}", changeNumber, splitCache.GetChangeNumber()));
                     }

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
@@ -1,5 +1,6 @@
-﻿using Common.Logging;
-using Splitio.Domain;
+﻿using Splitio.Domain;
+using Splitio.Services.Logger;
+using Splitio.Services.Shared.Classes;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace Splitio.Services.SplitFetcher.Classes
     public abstract class SplitChangeFetcher : ISplitChangeFetcher
     {
         private SplitChangesResult splitChanges;
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SplitChangeFetcher));
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SplitChangeFetcher));
 
         protected abstract Task<SplitChangesResult> FetchFromBackend(long since);
 
@@ -24,6 +25,7 @@ namespace Splitio.Services.SplitFetcher.Classes
                 Log.Error(string.Format("Exception caught executing Fetch since={0}", since), e);
                 splitChanges = null; 
             }                   
+
             return splitChanges;
         }
     }

--- a/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
+++ b/src/Splitio-net-core/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
@@ -1,6 +1,7 @@
-﻿using Common.Logging;
-using Splitio.CommonLibraries;
+﻿using Splitio.CommonLibraries;
+using Splitio.Services.Logger;
 using Splitio.Services.Metrics.Interfaces;
+using Splitio.Services.Shared.Classes;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
 using System.Diagnostics;
@@ -11,14 +12,14 @@ namespace Splitio.Services.SplitFetcher.Classes
 {
     public class SplitSdkApiClient : SdkApiClient, ISplitSdkApiClient
     {
+        private static readonly ISplitLogger Log = WrapperAdapter.GetLogger(typeof(SplitSdkApiClient));
+
         private const string SplitChangesUrlTemplate = "/api/splitChanges";
         private const string UrlParameterSince = "?since=";
         private const string SplitFetcherTime = "splitChangeFetcher.time";
         private const string SplitFetcherStatus = "splitChangeFetcher.status.{0}";
         private const string SplitFetcherException = "splitChangeFetcher.exception";
-
-        private static readonly ILog Log = LogManager.GetLogger(typeof(SplitSdkApiClient));
-
+        
         public SplitSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
 
         public async Task<string> FetchSplitChanges(long since)

--- a/src/Splitio-net-core/Splitio.csproj
+++ b/src/Splitio-net-core/Splitio.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>5.0.2</Version>
+    <Version>5.0.4</Version>
     <RootNamespace>Splitio</RootNamespace>
   </PropertyGroup>
 
@@ -35,6 +35,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45'">
     <PackageReference Include="Common.Logging" version="3.3.1" />
+    <PackageReference Include="Common.Logging.Core" version="3.3.1" />    
     <PackageReference Include="murmurhash-signed" version="1.0.2" />
     <PackageReference Include="Newtonsoft.Json" version="9.0.1" />
     <PackageReference Include="YamlDotNet" version="6.0.0" />

--- a/src/Splitio-net-core/Splitio.csproj
+++ b/src/Splitio-net-core/Splitio.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net40;net45</TargetFrameworks>
-    <AssemblyName>Splitio-net-core</AssemblyName>
-    <PackageId>Splitio-net-core</PackageId>
+    <AssemblyName>Splitio</AssemblyName>
+    <PackageId>Splitio</PackageId>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/Splitio-net-core/Splitio.csproj
+++ b/src/Splitio-net-core/Splitio.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net40;net45</TargetFrameworks>
@@ -8,7 +8,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>5.1.0</Version>
+    <Version>6.0.0</Version>
     <RootNamespace>Splitio</RootNamespace>
   </PropertyGroup>
 

--- a/src/Splitio-net-core/Splitio.csproj
+++ b/src/Splitio-net-core/Splitio.csproj
@@ -25,17 +25,16 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="Common.Logging" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="MurmurHash-net-core" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="System.IO.FileSystem.Watcher" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />
+    <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />    
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45'">
     <PackageReference Include="Common.Logging" version="3.3.1" />
-    <PackageReference Include="Common.Logging.Core" version="3.3.1" />
     <PackageReference Include="murmurhash-signed" version="1.0.2" />
     <PackageReference Include="Newtonsoft.Json" version="9.0.1" />
     <PackageReference Include="YamlDotNet" version="6.0.0" />

--- a/src/Splitio-net-core/Splitio.csproj
+++ b/src/Splitio-net-core/Splitio.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>5.0.4</Version>
+    <Version>5.1.0</Version>
     <RootNamespace>Splitio</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?

After this [issue](https://github.com/splitio/.net-core-client/issues/71) we decided change our logging framework for net core sdk. 

Now we have 2 implementations:
 - NET Framework sdk -> Continue with `Common.Logging`
 - NET Core sdk -> New implementation `Microsoft.Extensions.Logging`