### PR TITLE
Add setting to enable sending IP addresses (default should be ON)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 CHANGES
 
-5.0.3 (Coming soon)
+6.0.0 (Oct 30, 2019)
+- BREAKING CHANGE: Changed our logging framework implementation for .NET Core sdk. We use Microsoft.Extensions.Logging now.
+- Improved the performance of the getTreatments() and getTreatmentsWithConfig() call, by minimizing the amount of calls to redis when fetching splits.
+
+5.0.3 (Oct 10, 2019)
 - Refactor Evaluator.
 - Added Integration Tests.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@ CHANGES
 6.0.0 (Oct 30, 2019)
 - BREAKING CHANGE: Changed our logging framework implementation for .NET Core sdk. We use Microsoft.Extensions.Logging now.
 - Improved the performance of the getTreatments() and getTreatmentsWithConfig() call, by minimizing the amount of calls to redis when fetching splits.
+- Added IPAddressesEnabled to enable/disable sending MachineName and MachineIP headers when data is posted to Split Servers.
 
 5.0.3 (Oct 10, 2019)
 - Refactor Evaluator.

--- a/Splitio-net-core-tests/Integration Tests/JSONFileClientTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/JSONFileClientTests.cs
@@ -93,7 +93,11 @@ namespace Splitio_Tests.Integration_Tests
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
             var splitCacheMock = new Mock<ISplitCache>();
-            splitCacheMock.Setup(x => x.GetSplit(It.IsAny<string>())).Throws<Exception>();
+
+            splitCacheMock
+                .Setup(x => x.GetSplit(It.IsAny<string>()))
+                .Throws<Exception>();
+
             var client = new JSONFileClient($"{rootFilePath}splits_staging_3.json", "", _logMock.Object, null, splitCacheMock.Object, treatmentLogMock.Object);
 
             //Act           
@@ -315,7 +319,11 @@ namespace Splitio_Tests.Integration_Tests
             //Arrange
             var treatmentLogMock = new Mock<IListener<KeyImpression>>();
             var splitCacheMock = new Mock<ISplitCache>();
-            splitCacheMock.Setup(x => x.GetSplit(It.IsAny<string>())).Throws<Exception>();
+
+            splitCacheMock
+                .Setup(x => x.GetSplit(It.IsAny<string>()))
+                .Throws<Exception>();
+
             var client = new JSONFileClient($"{rootFilePath}splits_staging_3.json", "", _logMock.Object, null, splitCacheMock.Object, treatmentLogMock.Object);
 
             client.BlockUntilReady(1000);

--- a/Splitio-net-core-tests/Integration Tests/RedisAdapterTests.cs
+++ b/Splitio-net-core-tests/Integration Tests/RedisAdapterTests.cs
@@ -68,7 +68,7 @@ namespace Splitio_Tests.Integration_Tests
             var isSet3 = adapter.Set("test_key3", "test_value3");
 
             //Act
-            var result = adapter.Get(new RedisKey[]{"test_key", "test_key2", "test_key3"});
+            var result = adapter.MGet(new RedisKey[]{"test_key", "test_key2", "test_key3"});
 
             //Assert
             Assert.IsNotNull(result);
@@ -86,7 +86,7 @@ namespace Splitio_Tests.Integration_Tests
             var adapter = new RedisAdapter("", "", "");
 
             //Act
-            var result = adapter.Get(new RedisKey[] { "test_key", "test_key2", "test_key3" });
+            var result = adapter.MGet(new RedisKey[] { "test_key", "test_key2", "test_key3" });
 
             //Assert
             Assert.AreEqual(0, result.Count());

--- a/Splitio-net-core-tests/Unit Tests/Cache/RedisCacheBaseTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Cache/RedisCacheBaseTests.cs
@@ -118,7 +118,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             //Arrange
             var redisAdapterMock = new Mock<IRedisAdapter>();
             redisAdapterMock.Setup(x => x.IcrBy("SPLITIO/net-1.0.2/10.0.0.1/count.counter_test", 150)).Returns(150);
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             var result = cache.IncrementCount("counter_test", 150);
@@ -135,7 +135,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             //Arrange
             var redisAdapterMock = new Mock<IRedisAdapter>();
             redisAdapterMock.Setup(x => x.IcrBy("mycompany.SPLITIO/net-1.0.2/10.0.0.1/count.counter_test", 150)).Returns(150);
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "mycompany");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test", "mycompany");
 
             //Act
             var result = cache.IncrementCount("counter_test", 150);

--- a/Splitio-net-core-tests/Unit Tests/Cache/RedisImpressionCacheTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Cache/RedisImpressionCacheTests.cs
@@ -17,7 +17,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             //Arrange
             var key = "SPLITIO.impressions";
             var redisAdapterMock = new Mock<IRedisAdapter>();
-            var cache = new RedisImpressionsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisImpressionsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
             var impressions = new List<KeyImpression>
             {
                 new KeyImpression() { feature = "test", changeNumber = 100, keyName = "date", label = "testdate", time = 10000000 }

--- a/Splitio-net-core-tests/Unit Tests/Cache/RedisMetricsCacheTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Cache/RedisMetricsCacheTests.cs
@@ -1,12 +1,10 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Splitio.Services.Cache.Interfaces;
-using Splitio.Services.Cache.Classes;
-using Splitio.Services.Metrics.Interfaces;
-using System.Linq;
-using StackExchange.Redis;
 using Splitio.Redis.Services.Cache.Classes;
 using Splitio.Redis.Services.Cache.Interfaces;
+using Splitio.Services.Metrics.Interfaces;
+using StackExchange.Redis;
+using System.Linq;
 
 namespace Splitio_Tests.Unit_Tests.Cache
 {
@@ -23,7 +21,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             //Arrange
             var redisAdapterMock = new Mock<IRedisAdapter>();
             redisAdapterMock.Setup(x => x.IcrBy(metricsCountKeyPrefix + "counter_test", 150)).Returns(150);
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             var result = cache.IncrementCount("counter_test", 150);
@@ -42,7 +40,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.IcrBy(metricsCountKeyPrefix + "counter_test", 150)).Returns(150);
             redisAdapterMock.Setup(x => x.IcrBy(metricsCountKeyPrefix + "counter_test", 10)).Returns(160);
 
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.IncrementCount("counter_test", 150);
@@ -62,7 +60,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             var currentBucketPattern = bucketsPattern.Replace("*", "0");
             redisAdapterMock.Setup(x => x.Keys(bucketsPattern)).Returns(new RedisKey[]{ currentBucketPattern });
             redisAdapterMock.Setup(x => x.Get(currentBucketPattern)).Returns("1");
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.SetLatency("time_test", 1);
@@ -88,7 +86,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Keys(bucketsPattern)).Returns(new RedisKey[] { currentBucketPattern, currentBucketPattern2 });
             redisAdapterMock.Setup(x => x.Get(currentBucketPattern)).Returns("1");
             redisAdapterMock.Setup(x => x.Get(currentBucketPattern2)).Returns("2");
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.SetLatency("time_test", 1);
@@ -113,7 +111,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             var redisAdapterMock = new Mock<IRedisAdapter>();
             redisAdapterMock.Setup(x => x.Set(metricsGaugeKeyPrefix + "gauge_test", "150"));
             redisAdapterMock.Setup(x => x.Get(metricsGaugeKeyPrefix + "gauge_test")).Returns("150");
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.SetGauge("gauge_test", 150);
@@ -132,7 +130,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Set(metricsGaugeKeyPrefix + "gauge_test", "1234"));
             redisAdapterMock.Setup(x => x.Set(metricsGaugeKeyPrefix + "gauge_test", "4567"));
             redisAdapterMock.Setup(x => x.Get(metricsGaugeKeyPrefix + "gauge_test")).Returns("4567");
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.SetGauge("gauge_test", 1234);
@@ -155,7 +153,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Get(metricsCountKeyPrefix + "counter_test")).Returns("150");
             redisAdapterMock.Setup(x => x.Get(metricsCountKeyPrefix + "counter_test_2")).Returns("124");
 
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
             cache.IncrementCount("counter_test", 150);
             cache.IncrementCount("counter_test_2", 123);
             cache.IncrementCount("counter_test_2", 1);
@@ -184,7 +182,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Get(metricsGaugeKeyPrefix + "gauge_test")).Returns("1234");
             redisAdapterMock.Setup(x => x.Get(metricsGaugeKeyPrefix + "gauge_test_1")).Returns("4567");
 
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
             cache.SetGauge("gauge_test", 1234);
             cache.SetGauge("gauge_test_1", 4567);
 
@@ -219,7 +217,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Get(currentBucketPattern3)).Returns("1");
 
 
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
             cache.SetLatency("time_test", 1);
             cache.SetLatency("time_test", 9);
             cache.SetLatency("time_test", 8);

--- a/Splitio-net-core-tests/Unit Tests/Cache/RedisSplitCacheTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Cache/RedisSplitCacheTests.cs
@@ -105,7 +105,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
                 .Returns(new RedisKey[] { "test_split", "test_split2" });
 
             _redisAdapterMock
-                .Setup(x => x.Get(It.IsAny<RedisKey[]>()))
+                .Setup(x => x.MGet(It.IsAny<RedisKey[]>()))
                 .Returns(new RedisValue[] { splitJson, splitJson2 });
 
             _splitParserMock
@@ -128,7 +128,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
                 .Returns(new RedisKey[] { });
 
             _redisAdapterMock
-                .Setup(x => x.Get(It.IsAny<RedisKey[]>()))
+                .Setup(x => x.MGet(It.IsAny<RedisKey[]>()))
                 .Returns(new RedisValue[] { });
 
             //Act
@@ -150,7 +150,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
                 .Returns(new RedisKey[] { });
 
             _redisAdapterMock
-                .Setup(x => x.Get(It.IsAny<RedisKey[]>()))
+                .Setup(x => x.MGet(It.IsAny<RedisKey[]>()))
                 .Returns(expectedResult);
 
             //Act
@@ -297,6 +297,24 @@ namespace Splitio_Tests.Unit_Tests.Cache
             Assert.IsFalse(result);
         }
         #endregion
+
+        [TestMethod]
+        public void FetchMany_VerifyMGetCall_Once()
+        {
+            // Arrange.
+            var splitNames = new List<string> { "Split_1", "Split_2", "Split_3" };
+
+            _redisAdapterMock
+                .Setup(mock => mock.MGet(It.IsAny<RedisKey[]>()))
+                .Returns(new RedisValue[3]);
+
+            // Act.
+            var result = _redisSplitCache.FetchMany(splitNames);
+
+            // Assert.
+            _redisAdapterMock.Verify(mock => mock.MGet(It.IsAny<RedisKey[]>()), Times.Once);
+            _redisAdapterMock.Verify(mock => mock.Get(It.IsAny<string>()), Times.Never);
+        }
 
         private Split BuildSplit(string splitName)
         {

--- a/Splitio-net-core-tests/Unit Tests/Evaluator/EvaluatorTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Evaluator/EvaluatorTests.cs
@@ -51,7 +51,7 @@ namespace Splitio_Tests.Unit_Tests.Evaluator
 
             // Assert.
             Assert.AreEqual("control", result.Treatment);
-            Assert.AreEqual(Labels.LabelSplitNotFound, result.Label);
+            Assert.AreEqual(Labels.SplitNotFound, result.Label);
             _log.Verify(mock => mock.Warn($"GetTreatment: you passed {splitName} that does not exist in this environment, please double check what Splits exist in the web console."), Times.Once);
         }
 
@@ -81,7 +81,7 @@ namespace Splitio_Tests.Unit_Tests.Evaluator
             // Assert.
             Assert.AreEqual(parsedSplit.defaultTreatment, result.Treatment);
             Assert.AreEqual(parsedSplit.changeNumber, result.ChangeNumber);
-            Assert.AreEqual(Labels.LabelKilled, result.Label);
+            Assert.AreEqual(Labels.Killed, result.Label);
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace Splitio_Tests.Unit_Tests.Evaluator
             // Assert.
             Assert.AreEqual(parsedSplit.defaultTreatment, result.Treatment);
             Assert.AreEqual(parsedSplit.changeNumber, result.ChangeNumber);
-            Assert.AreEqual(Labels.LabelDefaultRule, result.Label);
+            Assert.AreEqual(Labels.DefaultRule, result.Label);
         }
 
         [TestMethod]
@@ -167,7 +167,7 @@ namespace Splitio_Tests.Unit_Tests.Evaluator
             // Assert.
             Assert.AreEqual(parsedSplit.defaultTreatment, result.Treatment);
             Assert.AreEqual(parsedSplit.changeNumber, result.ChangeNumber);
-            Assert.AreEqual(Labels.LabelTrafficAllocationFailed, result.Label);
+            Assert.AreEqual(Labels.TrafficAllocationFailed, result.Label);
         }
 
         [TestMethod]
@@ -351,7 +351,7 @@ namespace Splitio_Tests.Unit_Tests.Evaluator
 
             // Assert.
             Assert.AreEqual("off", result.Treatment);
-            Assert.AreEqual(Labels.LabelDefaultRule, result.Label);
+            Assert.AreEqual(Labels.DefaultRule, result.Label);
             Assert.AreEqual(parsedSplit.changeNumber, result.ChangeNumber);
         }
 
@@ -553,12 +553,12 @@ namespace Splitio_Tests.Unit_Tests.Evaluator
                 .Returns(18);
 
             _splitCache
-                .Setup(mock => mock.GetSplit(parsedSplitOff.name))
-                .Returns(parsedSplitOff);
-
-            _splitCache
-                .Setup(mock => mock.GetSplit(parsedSplitOn.name))
-                .Returns(parsedSplitOn);
+                .Setup(mock => mock.FetchMany(It.IsAny<List<string>>()))
+                .Returns(new List<ParsedSplit>
+                {
+                    parsedSplitOff,
+                    parsedSplitOn
+                });
 
             _splitter
                 .Setup(mock => mock.GetTreatment(key.bucketingKey, parsedSplitOn.seed, It.IsAny<List<PartitionDefinition>>(), parsedSplitOn.algo))

--- a/Splitio-net-core.Integration-tests/BaseIntegrationTests.cs
+++ b/Splitio-net-core.Integration-tests/BaseIntegrationTests.cs
@@ -135,6 +135,39 @@ namespace Splitio_net_core.Integration_tests
 
             ShutdownServer(httpClientMock);
         }
+
+        [TestMethod]
+        public void GetTreatment_WithtBUR_WhenTreatmentDoesntExist_ReturnsControl()
+        {
+            // Arrange.           
+            var httpClientMock = GetHttpClientMock();
+            var configurations = GetConfigurationOptions(httpClientMock);
+
+            var apikey = "apikey3";
+
+            var splitFactory = new SplitFactory(apikey, configurations);
+            var client = splitFactory.Client();
+
+            client.BlockUntilReady(10000);
+
+            // Act.
+            var result = client.GetTreatment("nico_test", "Random_Treatment");
+
+            // Assert.
+            Assert.AreEqual("control", result);
+
+            // Validate impressions in listener.
+            Thread.Sleep(2000);
+            var impressionQueue = ((IntegrationTestsImpressionListener)_impressionListener).GetQueue();
+            var keyImpressions = impressionQueue.FetchAll();
+
+            Assert.AreEqual(0, keyImpressions.Count);
+
+            //Validate impressions sent to the be.
+            AssertSentImpressions(0, httpClientMock);
+
+            ShutdownServer(httpClientMock);
+        }
         #endregion
 
         #region GetTreatmentWithConfig        
@@ -277,6 +310,39 @@ namespace Splitio_net_core.Integration_tests
 
             ShutdownServer(httpClientMock);
         }
+
+        [TestMethod]
+        public void GetTreatmentWithConfig_WithtBUR_WhenTreatmentDoesntExist_ReturnsControl()
+        {
+            // Arrange.           
+            var httpClientMock = GetHttpClientMock();
+            var configurations = GetConfigurationOptions(httpClientMock);
+
+            var apikey = "apikey3";
+
+            var splitFactory = new SplitFactory(apikey, configurations);
+            var client = splitFactory.Client();
+
+            client.BlockUntilReady(10000);
+
+            // Act.
+            var result = client.GetTreatment("nico_test", "Random_Treatment");
+
+            // Assert.
+            Assert.AreEqual("control", result);
+
+            // Validate impressions in listener.
+            Thread.Sleep(2000);
+            var impressionQueue = ((IntegrationTestsImpressionListener)_impressionListener).GetQueue();
+            var keyImpressions = impressionQueue.FetchAll();
+
+            Assert.AreEqual(0, keyImpressions.Count);
+
+            //Validate impressions sent to the be.
+            AssertSentImpressions(0, httpClientMock);
+
+            ShutdownServer(httpClientMock);
+        }
         #endregion
 
         #region GetTreatments
@@ -410,6 +476,69 @@ namespace Splitio_net_core.Integration_tests
 
             //Validate impressions sent to the be.
             AssertSentImpressions(4, httpClientMock, impression1, impression2, impression3, impression4);
+
+            ShutdownServer(httpClientMock);
+        }
+
+        [TestMethod]
+        public void GetTreatments_WithtBUR_WhenTreatmentsDoesntExist_ReturnsTreatments()
+        {
+            // Arrange.           
+            var httpClientMock = GetHttpClientMock();
+            var configurations = GetConfigurationOptions(httpClientMock);
+
+            var apikey = "apikey3";
+
+            var splitFactory = new SplitFactory(apikey, configurations);
+            var client = splitFactory.Client();
+
+            try
+            {
+                client.BlockUntilReady(10000);
+            }
+            catch
+            {
+                client.BlockUntilReady(100000);
+            }
+
+            // Act.
+            var result = client.GetTreatments("nico_test", new List<string> { "FACUNDO_TEST", "Random_Treatment", "MAURO_TEST", "Test_Save_1", "Random_Treatment_2", });
+
+            // Assert.
+            Assert.AreEqual("on", result["FACUNDO_TEST"]);
+            Assert.AreEqual("control", result["Random_Treatment"]);
+            Assert.AreEqual("off", result["MAURO_TEST"]);
+            Assert.AreEqual("off", result["Test_Save_1"]);
+            Assert.AreEqual("control", result["Random_Treatment_2"]);
+
+            // Validate impressions.
+            Thread.Sleep(2000);
+            var impressionQueue = ((IntegrationTestsImpressionListener)_impressionListener).GetQueue();
+            var keyImpressions = impressionQueue.FetchAll();
+
+            Assert.AreEqual(3, keyImpressions.Count);
+
+            var impression1 = keyImpressions
+                .Where(ki => ki.feature.Equals("FACUNDO_TEST"))
+                .Where(ki => ki.keyName.Equals("nico_test"))
+                .First();
+
+            var impression2 = keyImpressions
+                .Where(ki => ki.feature.Equals("MAURO_TEST"))
+                .Where(ki => ki.keyName.Equals("nico_test"))
+                .First();
+
+            var impression3 = keyImpressions
+                .Where(ki => ki.feature.Equals("Test_Save_1"))
+                .Where(ki => ki.keyName.Equals("nico_test"))
+                .First();
+
+            AssertImpression(impression1, 1506703262916, "FACUNDO_TEST", "nico_test", "whitelisted", "on");
+            AssertImpression(impression2, 1506703262966, "MAURO_TEST", "nico_test", "not in split", "off");
+            AssertImpression(impression3, 1503956389520, "Test_Save_1", "nico_test", "in segment all", "off");
+
+            //Validate impressions sent to the be.            
+            AssertSentImpressions(3, httpClientMock, impression1, impression2, impression3);
 
             ShutdownServer(httpClientMock);
         }
@@ -558,6 +687,73 @@ namespace Splitio_net_core.Integration_tests
 
             //Validate impressions sent to the be.
             AssertSentImpressions(4, httpClientMock, impression1, impression2, impression3, impression4);
+
+            ShutdownServer(httpClientMock);
+        }
+
+        [TestMethod]
+        public void GetTreatmentsWithConfig_WithtBUR_WhenTreatmentsDoesntExist_ReturnsTreatments()
+        {
+            // Arrange.           
+            var httpClientMock = GetHttpClientMock();
+            var configurations = GetConfigurationOptions(httpClientMock);
+
+            var apikey = "apikey3";
+
+            var splitFactory = new SplitFactory(apikey, configurations);
+            var client = splitFactory.Client();
+
+            try
+            {
+                client.BlockUntilReady(10000);
+            }
+            catch
+            {
+                client.BlockUntilReady(100000);
+            }
+
+            // Act.
+            var result = client.GetTreatmentsWithConfig("nico_test", new List<string> { "FACUNDO_TEST", "Random_Treatment", "MAURO_TEST", "Test_Save_1", "Random_Treatment_1" });
+
+            // Assert.
+            Assert.AreEqual("on", result["FACUNDO_TEST"].Treatment);
+            Assert.AreEqual("control", result["Random_Treatment"].Treatment);
+            Assert.AreEqual("off", result["MAURO_TEST"].Treatment);
+            Assert.AreEqual("off", result["Test_Save_1"].Treatment);
+            Assert.AreEqual("control", result["Random_Treatment_1"].Treatment);
+
+            Assert.AreEqual("{\"color\":\"green\"}", result["FACUNDO_TEST"].Config);
+            Assert.AreEqual("{\"version\":\"v1\"}", result["MAURO_TEST"].Config);
+            Assert.IsNull(result["Test_Save_1"].Config);
+
+            // Validate impressions.
+            Thread.Sleep(2000);
+            var impressionQueue = ((IntegrationTestsImpressionListener)_impressionListener).GetQueue();
+            var keyImpressions = impressionQueue.FetchAll();
+
+            Assert.AreEqual(3, keyImpressions.Count);
+
+            var impression1 = keyImpressions
+                .Where(ki => ki.feature.Equals("FACUNDO_TEST"))
+                .Where(ki => ki.keyName.Equals("nico_test"))
+                .First();
+
+            var impression2 = keyImpressions
+                .Where(ki => ki.feature.Equals("MAURO_TEST"))
+                .Where(ki => ki.keyName.Equals("nico_test"))
+                .First();
+
+            var impression3 = keyImpressions
+                .Where(ki => ki.feature.Equals("Test_Save_1"))
+                .Where(ki => ki.keyName.Equals("nico_test"))
+                .First();
+
+            AssertImpression(impression1, 1506703262916, "FACUNDO_TEST", "nico_test", "whitelisted", "on");
+            AssertImpression(impression2, 1506703262966, "MAURO_TEST", "nico_test", "not in split", "off");
+            AssertImpression(impression3, 1503956389520, "Test_Save_1", "nico_test", "in segment all", "off");
+
+            //Validate impressions sent to the be.
+            AssertSentImpressions(3, httpClientMock, impression1, impression2, impression3);
 
             ShutdownServer(httpClientMock);
         }

--- a/Splitio-net-core.Integration-tests/BaseIntegrationTests.cs
+++ b/Splitio-net-core.Integration-tests/BaseIntegrationTests.cs
@@ -1083,7 +1083,7 @@ namespace Splitio_net_core.Integration_tests
             Assert.AreEqual(treatment, impression.treatment);
         }
         
-        protected abstract ConfigurationOptions GetConfigurationOptions(HttpClientMock httpClientMock = null, int? eventsPushRate = null, int? eventsQueueSize = null, int? featuresRefreshRate = null);
+        protected abstract ConfigurationOptions GetConfigurationOptions(HttpClientMock httpClientMock = null, int? eventsPushRate = null, int? eventsQueueSize = null, int? featuresRefreshRate = null, bool? ipAddressesEnabled = null);
 
         protected abstract void ShutdownServer(HttpClientMock httpClientMock = null);
 

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisAdapter.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisAdapter.cs
@@ -91,7 +91,7 @@ namespace Splitio.Redis.Services.Cache.Classes
             }
         }
 
-        public RedisValue[] Get(RedisKey[] keys)
+        public RedisValue[] MGet(RedisKey[] keys)
         {
             try
             {

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisCacheBase.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisCacheBase.cs
@@ -5,39 +5,49 @@ namespace Splitio.Redis.Services.Cache.Classes
     public abstract class RedisCacheBase
     {
         private const string RedisKeyPrefixFormat = "SPLITIO/{sdk-language-version}/{instance-id}/";
-        protected IRedisAdapter redisAdapter;
-        protected string redisKeyPrefix;
 
+        protected IRedisAdapter _redisAdapter;
+
+        protected string RedisKeyPrefix;
         protected string UserPrefix;
         protected string SdkVersion;
         protected string MachineIp;
+        protected string MachineName;
 
-        public RedisCacheBase(IRedisAdapter redisAdapter, string userPrefix = null)
+        public RedisCacheBase(IRedisAdapter redisAdapter, 
+            string userPrefix = null)
         {
+            _redisAdapter = redisAdapter;
+
             UserPrefix = userPrefix;
-            this.redisAdapter = redisAdapter;
-            redisKeyPrefix = "SPLITIO.";
+            RedisKeyPrefix = "SPLITIO.";
 
             if (!string.IsNullOrEmpty(userPrefix))
             {
-                redisKeyPrefix = userPrefix + "." + redisKeyPrefix;
+                RedisKeyPrefix = userPrefix + "." + RedisKeyPrefix;
             }
         }
 
-        public RedisCacheBase(IRedisAdapter redisAdapter, string machineIP, string sdkVersion, string userPrefix = null)
+        public RedisCacheBase(IRedisAdapter redisAdapter, 
+            string machineIP, 
+            string sdkVersion, 
+            string machineName, 
+            string userPrefix = null)
         {
+            _redisAdapter = redisAdapter;
+
             UserPrefix = userPrefix;
             MachineIp = machineIP;
             SdkVersion = sdkVersion;
+            MachineName = machineName;
 
-            this.redisAdapter = redisAdapter;
-            redisKeyPrefix = RedisKeyPrefixFormat
+            RedisKeyPrefix = RedisKeyPrefixFormat
                 .Replace("{sdk-language-version}", sdkVersion)
                 .Replace("{instance-id}", machineIP);
 
             if (!string.IsNullOrEmpty(userPrefix))
             {
-                redisKeyPrefix = userPrefix + "." + redisKeyPrefix;
+                RedisKeyPrefix = userPrefix + "." + RedisKeyPrefix;
             }
         }
     }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisEventsCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisEventsCache.cs
@@ -7,13 +7,15 @@ namespace Splitio.Redis.Services.Cache.Classes
 {
     public class RedisEventsCache : RedisCacheBase, ISimpleCache<WrappedEvent>
     {
-        private const string eventKeyPrefix = "events";
         private readonly string _machineName;
         private readonly string _machineIP;
         private readonly string _sdkVersion;
 
-        public RedisEventsCache(IRedisAdapter redisAdapter, string machineName, string machineIP, string sdkVersion, string userPrefix = null)
-            : base(redisAdapter, userPrefix) 
+        public RedisEventsCache(IRedisAdapter redisAdapter, 
+            string machineName,
+            string machineIP, 
+            string sdkVersion, 
+            string userPrefix = null) : base(redisAdapter, userPrefix) 
         {
             _machineName = machineName;
             _machineIP = machineIP;
@@ -22,13 +24,13 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public void AddItem(WrappedEvent item)
         {
-            var key = redisKeyPrefix + eventKeyPrefix;
             var eventJson = JsonConvert.SerializeObject(new
             {
                 m = new { s = _sdkVersion, i = _machineIP, n = _machineName },
                 e = item.Event
             });
-            redisAdapter.ListRightPush(key, eventJson);
+
+            _redisAdapter.ListRightPush($"{RedisKeyPrefix}events", eventJson);
         }
     }
 }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisImpressionsCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisImpressionsCache.cs
@@ -11,11 +11,12 @@ namespace Splitio.Redis.Services.Cache.Classes
 {
     public class RedisImpressionsCache : RedisCacheBase, ISimpleCache<IList<KeyImpression>>
     {
-        private const string impressionKeyPrefix = "impressions.";
-
-        public RedisImpressionsCache(IRedisAdapter redisAdapter, string machineIP, string sdkVersion, string userPrefix = null)
-            : base(redisAdapter, machineIP, sdkVersion, userPrefix) 
-        {}
+        public RedisImpressionsCache(IRedisAdapter redisAdapter, 
+            string machineIP, 
+            string sdkVersion, 
+            string machineName, 
+            string userPrefix = null) : base(redisAdapter, machineIP, sdkVersion, machineName, userPrefix) 
+        { }
 
         public void AddItem(IList<KeyImpression> items)
         {
@@ -23,15 +24,15 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             var impressions = items.Select(item => JsonConvert.SerializeObject(new
             {
-                m = new { s = SdkVersion, i = MachineIp, n = Environment.MachineName },
+                m = new { s = SdkVersion, i = MachineIp, n = MachineName },
                 i = new { k = item.keyName, b = item.bucketingKey, f = item.feature, t = item.treatment, r = item.label, c = item.changeNumber, m = item.time }
             }));
 
-            var lengthRedis = redisAdapter.ListRightPush(key, impressions.Select(i => (RedisValue)i).ToArray());
+            var lengthRedis = _redisAdapter.ListRightPush(key, impressions.Select(i => (RedisValue)i).ToArray());
 
             if (lengthRedis == items.Count)
             {
-                redisAdapter.KeyExpire(key, new TimeSpan(0, 0, 3600));
+                _redisAdapter.KeyExpire(key, new TimeSpan(0, 0, 3600));
             }
         }
     }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisMetricsCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisMetricsCache.cs
@@ -9,22 +9,25 @@ namespace Splitio.Redis.Services.Cache.Classes
 {
     public class RedisMetricsCache : RedisCacheBase, IMetricsCache
     {
-        private ILatencyTracker latencyTracker;
         private const string metricsLatencyKeyPrefix = "latency.{metricName}.bucket.{bucketNumber}";
         private const string metricsCountKeyPrefix = "count.";
         private const string metricsGaugeKeyPrefix = "gauge.";
 
-        public RedisMetricsCache(IRedisAdapter redisAdapter, string machineIP, string sdkVersion, string userPrefix = null)
-            : base(redisAdapter, machineIP, sdkVersion, userPrefix) 
+        private readonly ILatencyTracker _latencyTracker;        
+
+        public RedisMetricsCache(IRedisAdapter redisAdapter, 
+            string machineIP, 
+            string sdkVersion, 
+            string machineName, 
+            string userPrefix = null) : base(redisAdapter, machineIP, sdkVersion, machineName, userPrefix) 
         {
-            this.latencyTracker = new BinarySearchLatencyTracker();       
+            _latencyTracker = new BinarySearchLatencyTracker();       
         }
 
         public Counter IncrementCount(string name, long delta)
         {
-            var key = redisKeyPrefix + metricsCountKeyPrefix + name;
-            var result = redisAdapter.IcrBy(key, delta);
-
+            var key = $"{RedisKeyPrefix}{metricsCountKeyPrefix}{name}";
+            var result = _redisAdapter.IcrBy(key, delta);
             var counter = new Counter(); //TODO: counter.count is losing its original value!!
             counter.AddDelta(result);
 
@@ -33,8 +36,8 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public Counter GetCount(string name)
         {
-            var key = redisKeyPrefix + metricsCountKeyPrefix + name;
-            var result = redisAdapter.Get(key);
+            var key = $"{RedisKeyPrefix}{metricsCountKeyPrefix}{name}";
+            var result = _redisAdapter.Get(key);
             var counter = new Counter(); //TODO: counter.count is losing its original value!!
             counter.AddDelta(long.Parse(result));
 
@@ -44,29 +47,34 @@ namespace Splitio.Redis.Services.Cache.Classes
         public Dictionary<string, Counter> FetchAllCountersAndClear()
         {
             var result = new Dictionary<string, Counter>();
-            var pattern = redisKeyPrefix + metricsCountKeyPrefix + "*";
-            var keys = redisAdapter.Keys(pattern);
+            var pattern = $"{RedisKeyPrefix}{metricsCountKeyPrefix}*";
+            var keys = _redisAdapter.Keys(pattern);
+
             foreach (var count in keys)
             {
-                var value = redisAdapter.Get(count);
-                var countName = ((string)count).Replace(redisKeyPrefix + metricsCountKeyPrefix, "");
+                var value = _redisAdapter.Get(count);
+                var countName = ((string)count).Replace(RedisKeyPrefix + metricsCountKeyPrefix, "");
                 var counterValue = long.Parse(value);
+
                 result.Add(countName, new Counter(counterValue)); //TODO: counter.count is losing its original value!!
-                redisAdapter.Del(count);
+
+                _redisAdapter.Del(count);
             }
+
             return result;
         }
 
         public void SetGauge(string name, long gauge)
         {
-            var key = redisKeyPrefix + metricsGaugeKeyPrefix + name;
-            redisAdapter.Set(key, gauge.ToString());
+            var key = $"{RedisKeyPrefix}{metricsGaugeKeyPrefix}{name}";
+
+            _redisAdapter.Set(key, gauge.ToString());
         }
 
         public long GetGauge(string name)
         {
-            var key = redisKeyPrefix + metricsGaugeKeyPrefix + name;
-            string value = redisAdapter.Get(key);
+            var key = $"{RedisKeyPrefix}{metricsGaugeKeyPrefix}{name}";
+            var value = _redisAdapter.Get(key);
 
             return long.Parse(value);
         }
@@ -74,47 +82,57 @@ namespace Splitio.Redis.Services.Cache.Classes
         public Dictionary<string, long> FetchAllGaugesAndClear()
         {
             var result = new Dictionary<string, long>();
-            var pattern = redisKeyPrefix + metricsGaugeKeyPrefix + "*";
-            var keys = redisAdapter.Keys(pattern);
+            var pattern = $"{RedisKeyPrefix}{metricsGaugeKeyPrefix}*";
+            var keys = _redisAdapter.Keys(pattern);
+
             foreach (var gauge in keys)
             {
-                var value = redisAdapter.Get(gauge);
-                var gaugeName = ((string)gauge).Replace(redisKeyPrefix + metricsGaugeKeyPrefix, "");
+                var value = _redisAdapter.Get(gauge);
+                var gaugeName = ((string)gauge).Replace(RedisKeyPrefix + metricsGaugeKeyPrefix, "");
+
                 result.Add(gaugeName, long.Parse(value));
-                redisAdapter.Del(gauge);
+
+                _redisAdapter.Del(gauge);
             }
+
             return result;
         }
 
         public void SetLatency(string name, long value)
         {
-            var bucketToIncrement = ((BinarySearchLatencyTracker)latencyTracker).FindIndex(value * 1000);
-            var key = redisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}", name).Replace("{bucketNumber}", bucketToIncrement.ToString());
-            var result = redisAdapter.IcrBy(key, 1);
+            var bucketToIncrement = ((BinarySearchLatencyTracker)_latencyTracker).FindIndex(value * 1000);
+            var key = RedisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}", name).Replace("{bucketNumber}", bucketToIncrement.ToString());
+
+            _redisAdapter.IcrBy(key, 1);
         }
 
         public ILatencyTracker GetLatencyTracker(string name)
         {
-            var bucketsPattern = redisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}", name).Replace("{bucketNumber}", "*");
-            var keys = redisAdapter.Keys(bucketsPattern);
             ILatencyTracker result = new BinarySearchLatencyTracker();
+
+            var bucketsPattern = RedisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}", name).Replace("{bucketNumber}", "*");
+            var keys = _redisAdapter.Keys(bucketsPattern);
+            
             foreach (var key in keys)
             {
                 var bucketPrefix = bucketsPattern.Replace("*", "");
                 var bucket = ((string)key).Replace(bucketPrefix, "");
                 var currentBucketPattern = bucketsPattern.Replace("*", bucket);
-                var valueString = redisAdapter.Get(currentBucketPattern);
-                long value = long.Parse(valueString);
+                var valueString = _redisAdapter.Get(currentBucketPattern);
+                var value = long.Parse(valueString);
+
                 result.SetLatencyCount(int.Parse(bucket), value);
             }
+
             return result;
         }
 
         public Dictionary<string, ILatencyTracker> FetchAllLatencyTrackersAndClear()
         {
             var result = new Dictionary<string, ILatencyTracker>();
-            var pattern = redisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}.bucket.{bucketNumber}", "*");
-            var keys = redisAdapter.Keys(pattern);
+            var pattern = RedisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}.bucket.{bucketNumber}", "*");
+            var keys = _redisAdapter.Keys(pattern);
+
             foreach(var key in keys)
             {
                 var keyParts = ((string)key).Split(new Char[]{'.', '/'});
@@ -123,21 +141,22 @@ namespace Splitio.Redis.Services.Cache.Classes
                 string name = keyParts[latencyPosition + 1];
                 string bucket = keyParts[bucketPosition + 1];
 
-                ILatencyTracker tracker;
-                result.TryGetValue(name, out tracker);
+                result.TryGetValue(name, out ILatencyTracker tracker);
+
                 if (tracker == null)
                 {
                     tracker = new BinarySearchLatencyTracker();                
                     result.Add(name, tracker);
                 }
 
-                var valueString = redisAdapter.Get(key);
-                long value = long.Parse(valueString);
+                var valueString = _redisAdapter.Get(key);
+                var value = long.Parse(valueString);
                 
                 tracker.SetLatencyCount(int.Parse(bucket), value);
 
-                redisAdapter.Del(key);
+                _redisAdapter.Del(key);
             }
+
             return result;
         }      
     }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisSplitCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisSplitCache.cs
@@ -3,6 +3,7 @@ using Splitio.Domain;
 using Splitio.Redis.Services.Cache.Interfaces;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Parsing.Interfaces;
+using StackExchange.Redis;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -49,7 +50,7 @@ namespace Splitio.Redis.Services.Cache.Classes
         {
             var pattern = redisKeyPrefix + splitKeyPrefix + "*";
             var splitKeys = redisAdapter.Keys(pattern);
-            var splitValues = redisAdapter.Get(splitKeys);
+            var splitValues = redisAdapter.MGet(splitKeys);
 
             if (splitValues != null && splitValues.Any())
             {
@@ -125,6 +126,30 @@ namespace Splitio.Redis.Services.Cache.Classes
         public void Flush()
         {
             throw new System.NotImplementedException();
+        }
+
+        public List<ParsedSplit> FetchMany(List<string> splitNames)
+        {
+            if (!splitNames.Any()) return new List<ParsedSplit>();
+
+            var redisKey = new List<RedisKey>();
+
+            foreach (var name in splitNames)
+            {
+                redisKey.Add($"{redisKeyPrefix}{splitKeyPrefix}{name}");
+            }
+                        
+            var splitValues = redisAdapter.MGet(redisKey.ToArray());
+
+            if (splitValues == null || !splitValues.Any()) return new List<ParsedSplit>();
+
+            var splits = splitValues
+                .Where(s => !s.IsNull)
+                .Select(s => _splitParser.Parse(JsonConvert.DeserializeObject<Split>(s)));
+
+            return splits
+                .Where(s => s != null)
+                .ToList();
         }
     }
 }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisSplitCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisSplitCache.cs
@@ -26,8 +26,8 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public long GetChangeNumber()
         {
-            var key = redisKeyPrefix + splitsKeyPrefix + "till";
-            var changeNumberString = redisAdapter.Get(key);
+            var key = $"{RedisKeyPrefix}{splitsKeyPrefix}till";
+            var changeNumberString = _redisAdapter.Get(key);
             var result = long.TryParse(changeNumberString, out long changeNumberParsed);
             
             return result ? changeNumberParsed : -1;
@@ -35,8 +35,8 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public ParsedSplit GetSplit(string splitName)
         {
-            var key = redisKeyPrefix + splitKeyPrefix + splitName;
-            var splitJson = redisAdapter.Get(key);
+            var key = $"{RedisKeyPrefix}{splitKeyPrefix}{splitName}";
+            var splitJson = _redisAdapter.Get(key);
 
             if (string.IsNullOrEmpty(splitJson))
                 return null;
@@ -48,9 +48,9 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public List<ParsedSplit> GetAllSplits()
         {
-            var pattern = redisKeyPrefix + splitKeyPrefix + "*";
-            var splitKeys = redisAdapter.Keys(pattern);
-            var splitValues = redisAdapter.MGet(splitKeys);
+            var pattern = $"{RedisKeyPrefix}{splitKeyPrefix}*";
+            var splitKeys = _redisAdapter.Keys(pattern);
+            var splitValues = _redisAdapter.MGet(splitKeys);
 
             if (splitValues != null && splitValues.Any())
             {
@@ -68,8 +68,8 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public List<string> GetKeys()
         {
-            var pattern = redisKeyPrefix + splitKeyPrefix + "*";
-            var splitKeys = redisAdapter.Keys(pattern);
+            var pattern = $"{RedisKeyPrefix}{splitKeyPrefix}*";
+            var splitKeys = _redisAdapter.Keys(pattern);
             var result = splitKeys.Select(x => x.ToString()).ToList();
 
             return result;
@@ -84,7 +84,7 @@ namespace Splitio.Redis.Services.Cache.Classes
         {
             if (string.IsNullOrEmpty(trafficType)) return false;
 
-            var value = redisAdapter.Get(GetTrafficTypeKey(trafficType));
+            var value = _redisAdapter.Get(GetTrafficTypeKey(trafficType));
 
             var quantity = value ?? "0";
 
@@ -95,7 +95,7 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         private string GetTrafficTypeKey(string type)
         {
-            return $"{redisKeyPrefix}trafficType.{type}";
+            return $"{RedisKeyPrefix}trafficType.{type}";
         }
 
         public void AddSplit(string splitName, SplitBase split)
@@ -136,10 +136,10 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             foreach (var name in splitNames)
             {
-                redisKey.Add($"{redisKeyPrefix}{splitKeyPrefix}{name}");
+                redisKey.Add($"{RedisKeyPrefix}{splitKeyPrefix}{name}");
             }
                         
-            var splitValues = redisAdapter.MGet(redisKey.ToArray());
+            var splitValues = _redisAdapter.MGet(redisKey.ToArray());
 
             if (splitValues == null || !splitValues.Any()) return new List<ParsedSplit>();
 

--- a/Splitio-net-core.Redis/Services/Cache/Interfaces/IRedisAdapter.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Interfaces/IRedisAdapter.cs
@@ -9,7 +9,7 @@ namespace Splitio.Redis.Services.Cache.Interfaces
 
         string Get(string key);
 
-        RedisValue[] Get(RedisKey[] keys);
+        RedisValue[] MGet(RedisKey[] keys);
 
         RedisKey[] Keys(string pattern);
 

--- a/Splitio-net-core.Redis/Services/Client/Classes/RedisClient.cs
+++ b/Splitio-net-core.Redis/Services/Client/Classes/RedisClient.cs
@@ -97,8 +97,8 @@ namespace Splitio.Redis.Services.Client.Classes
             BuildParser();
             splitCache = new RedisSplitCache(redisAdapter, _splitParser, RedisUserPrefix);
             
-            metricsCache = new RedisMetricsCache(redisAdapter, SdkMachineIP, SdkVersion, RedisUserPrefix);
-            impressionsCacheRedis = new RedisImpressionsCache(redisAdapter, SdkMachineIP, SdkVersion, RedisUserPrefix);
+            metricsCache = new RedisMetricsCache(redisAdapter, SdkMachineIP, SdkVersion, SdkMachineName, RedisUserPrefix);
+            impressionsCacheRedis = new RedisImpressionsCache(redisAdapter, SdkMachineIP, SdkVersion, SdkMachineName, RedisUserPrefix);
             eventsCache = new RedisEventsCache(redisAdapter, SdkMachineName, SdkMachineIP, SdkVersion, RedisUserPrefix);
 
             _trafficTypeValidator = new TrafficTypeValidator(splitCache);

--- a/src/Splitio-net-core/Domain/Labels.cs
+++ b/src/Splitio-net-core/Domain/Labels.cs
@@ -2,11 +2,11 @@
 {
     public class Labels
     {
-        public static string LabelKilled => "killed";
-        public static string LabelDefaultRule => "default rule";
-        public static string LabelSplitNotFound => "definition not found";
-        public static string LabelException => "exception";
-        public static string LabelTrafficAllocationFailed => "not in split";
-        public static string LabelClientNotReady => "not ready";
+        public static string Killed => "killed";
+        public static string DefaultRule => "default rule";
+        public static string SplitNotFound => "definition not found";
+        public static string Exception => "exception";
+        public static string TrafficAllocationFailed => "not in split";
+        public static string ClientNotReady => "not ready";
     }
 }

--- a/src/Splitio-net-core/Domain/Operations.cs
+++ b/src/Splitio-net-core/Domain/Operations.cs
@@ -1,0 +1,10 @@
+﻿namespace Splitio.Domain
+{
+    public class Operations
+    {
+        public static string SdkGetTreatment => "sdk.getTreatment";
+        public static string SdkGetTreatments => "sdk.getTreatments";
+        public static string SdkGetTreatmentWithConfig => "sdk.getTreatmentWithConfig";
+        public static string SdkGetTreatmentsWithConfig => "sdk.getTreatmentsWithConfig";
+    }
+}

--- a/src/Splitio-net-core/Services/Cache/Classes/InMemorySplitCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Classes/InMemorySplitCache.cs
@@ -148,5 +148,19 @@ namespace Splitio.Services.Cache.Classes
                 _trafficTypes.TryUpdate(split.trafficTypeName, newQuantity, quantity);
             }
         }
+
+        public List<ParsedSplit> FetchMany(List<string> splitNames)
+        {
+            var splits = new List<ParsedSplit>();
+
+            foreach (var name in splitNames)
+            {
+                splits.Add(GetSplit(name));
+            }
+
+            return splits
+                .Where(s => s != null)
+                .ToList();
+        }
     }
 }

--- a/src/Splitio-net-core/Services/Cache/Interfaces/ISplitCache.cs
+++ b/src/Splitio-net-core/Services/Cache/Interfaces/ISplitCache.cs
@@ -22,5 +22,7 @@ namespace Splitio.Services.Cache.Interfaces
         void Clear();
 
         bool TrafficTypeExists(string trafficType);
+
+        List<ParsedSplit> FetchMany(List<string> splitNames);
     }
 }

--- a/src/Splitio-net-core/Services/Client/Classes/ConfigurationOptions.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/ConfigurationOptions.cs
@@ -28,5 +28,6 @@ namespace Splitio.Services.Client.Classes
         public bool? LabelsEnabled { get; set; }
         public IImpressionListener ImpressionListener { get; set; }
         public CacheAdapterConfigurationOptions CacheAdapterConfig { get; set; }
+        public bool? IPAddressesEnabled { get; set; }
     }
 }

--- a/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
@@ -170,6 +170,7 @@ namespace Splitio.Services.Client.Classes
             treatmentLog = new SelfUpdatingTreatmentLog(treatmentSdkApiClient, TreatmentLogRefreshRate, impressionsCache);
             impressionListener = new AsynchronousListener<KeyImpression>(WrapperAdapter.GetLogger("AsynchronousImpressionListener"));
             ((IAsynchronousListener<KeyImpression>)impressionListener).AddListener(treatmentLog);
+
             if (config.ImpressionListener != null)
             {
                 ((IAsynchronousListener<KeyImpression>)impressionListener).AddListener(config.ImpressionListener);
@@ -198,12 +199,15 @@ namespace Splitio.Services.Client.Classes
 
         private void BuildSdkApiClients()
         {
-            var header = new HTTPHeader();
-            header.authorizationApiKey = ApiKey;
-            header.splitSDKVersion = SdkVersion;
-            header.splitSDKSpecVersion = SdkSpecVersion;
-            header.splitSDKMachineName = SdkMachineName;
-            header.splitSDKMachineIP = SdkMachineIP;
+            var header = new HTTPHeader
+            {
+                authorizationApiKey = ApiKey,
+                splitSDKVersion = SdkVersion,
+                splitSDKSpecVersion = SdkSpecVersion,
+                splitSDKMachineName = SdkMachineName,
+                splitSDKMachineIP = SdkMachineIP
+            };
+
             metricsSdkApiClient = new MetricsSdkApiClient(header, EventsBaseUrl, HttpConnectionTimeout, HttpReadTimeout);
             BuildMetricsLog();
             splitSdkApiClient = new SplitSdkApiClient(header, BaseUrl, HttpConnectionTimeout, HttpReadTimeout, metricsLog);

--- a/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SplitClient.cs
@@ -26,10 +26,6 @@ namespace Splitio.Services.Client.Classes
         protected readonly IWrapperAdapter _wrapperAdapter;
 
         protected const string Control = "control";
-        protected const string SdkGetTreatment = "sdk.getTreatment";
-        protected const string SdkGetTreatments = "sdk.getTreatments";
-        protected const string SdkGetTreatmentWithConfig = "sdk.getTreatmentWithConfig";
-        protected const string SdkGetTreatmentsWithConfig = "sdk.getTreatmentsWithConfig";
 
         protected bool LabelsEnabled;
         protected bool Destroyed;
@@ -74,7 +70,7 @@ namespace Splitio.Services.Client.Classes
 
         public SplitResult GetTreatmentWithConfig(Key key, string feature, Dictionary<string, object> attributes = null)
         {
-            var result = GetTreatmentResult(key, feature, SdkGetTreatmentWithConfig, nameof(GetTreatmentWithConfig), attributes);
+            var result = GetTreatmentResult(key, feature, Operations.SdkGetTreatmentWithConfig, nameof(GetTreatmentWithConfig), attributes);
 
             return new SplitResult
             {
@@ -90,7 +86,7 @@ namespace Splitio.Services.Client.Classes
 
         public virtual string GetTreatment(Key key, string feature, Dictionary<string, object> attributes = null)
         {
-            var result = GetTreatmentResult(key, feature, SdkGetTreatment, nameof(GetTreatment), attributes);
+            var result = GetTreatmentResult(key, feature, Operations.SdkGetTreatment, nameof(GetTreatment), attributes);
 
             return result.Treatment;
         }
@@ -102,7 +98,7 @@ namespace Splitio.Services.Client.Classes
 
         public Dictionary<string, SplitResult> GetTreatmentsWithConfig(Key key, List<string> features, Dictionary<string, object> attributes = null)
         {
-            var results = GetTreatmentsResult(key, features, SdkGetTreatmentsWithConfig, nameof(GetTreatmentsWithConfig), attributes);
+            var results = GetTreatmentsResult(key, features, Operations.SdkGetTreatmentsWithConfig, nameof(GetTreatmentsWithConfig), attributes);
 
             return results
                 .ToDictionary(r => r.Key, r => new SplitResult
@@ -119,7 +115,7 @@ namespace Splitio.Services.Client.Classes
 
         public Dictionary<string, string> GetTreatments(Key key, List<string> features, Dictionary<string, object> attributes = null)
         {
-            var results = GetTreatmentsResult(key, features, SdkGetTreatments, nameof(GetTreatments), attributes);
+            var results = GetTreatmentsResult(key, features, Operations.SdkGetTreatments, nameof(GetTreatments), attributes);
 
             return results
                 .ToDictionary(r => r.Key, r => r.Value.Treatment);
@@ -242,7 +238,7 @@ namespace Splitio.Services.Client.Classes
                 metricsLog.Time(operation, result.ElapsedMilliseconds);
             }
 
-            if (!Labels.LabelSplitNotFound.Equals(result.Label))
+            if (!Labels.SplitNotFound.Equals(result.Label))
             {
                 ImpressionLog(new List<KeyImpression>
                 {
@@ -279,7 +275,7 @@ namespace Splitio.Services.Client.Classes
                 {
                     treatmentsForFeatures.Add(treatmentResult.Key, treatmentResult.Value);
 
-                    if (!Labels.LabelSplitNotFound.Equals(treatmentResult.Value.Label))
+                    if (!Labels.SplitNotFound.Equals(treatmentResult.Value.Label))
                     {
                         ImpressionsQueue.Add(BuildImpression(key.matchingKey, treatmentResult.Key, treatmentResult.Value.Treatment, CurrentTimeHelper.CurrentTimeMillis(), treatmentResult.Value.ChangeNumber, LabelsEnabled ? treatmentResult.Value.Label : null, key.bucketingKeyHadValue ? key.bucketingKey : null));
                     }

--- a/src/Splitio-net-core/Services/Evaluator/Evaluator.cs
+++ b/src/Splitio-net-core/Services/Evaluator/Evaluator.cs
@@ -7,6 +7,7 @@ using Splitio.Services.Shared.Classes;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Splitio.Services.Evaluator
 {
@@ -40,14 +41,72 @@ namespace Splitio.Services.Evaluator
             {
                 var parsedSplit = _splitCache.GetSplit(featureName);
 
+                return EvaluateTreatment(key, parsedSplit, featureName, clock, attributes);
+            }
+            catch (Exception e)
+            {
+                _log.Error($"Exception caught getting treatment for feature: {featureName}", e);
+
+                return new TreatmentResult(Labels.Exception, Control, elapsedMilliseconds: clock.ElapsedMilliseconds);
+            }
+        }
+
+        public MultipleEvaluatorResult EvaluateFeatures(Key key, List<string> featureNames, Dictionary<string, object> attributes = null)
+        {
+            var treatmentsForFeatures = new Dictionary<string, TreatmentResult>();
+            var clock = new Stopwatch();
+            clock.Start();
+
+            try
+            {
+                var splits = _splitCache.FetchMany(featureNames);
+
+                foreach (var feature in featureNames)
+                {
+                    var split = splits.FirstOrDefault(s => feature.Equals(s?.name));
+
+                    var result = EvaluateTreatment(key, split, feature, attributes: attributes);
+
+                    treatmentsForFeatures.Add(feature, result);
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error($"Exception caught getting treatments", e);
+
+                foreach (var name in featureNames)
+                {
+                    treatmentsForFeatures.Add(name, new TreatmentResult(Labels.Exception, Control, elapsedMilliseconds: clock.ElapsedMilliseconds));
+                }
+            }
+
+            return new MultipleEvaluatorResult
+            {
+                TreatmentResults = treatmentsForFeatures,
+                ElapsedMilliseconds = clock.ElapsedMilliseconds
+            };
+        }
+        #endregion
+
+        #region Private Methods
+        private TreatmentResult EvaluateTreatment(Key key, ParsedSplit parsedSplit, string featureName, Stopwatch clock = null, Dictionary<string, object> attributes = null)
+        {
+            try
+            {
+                if (clock == null)
+                {
+                    clock = new Stopwatch();
+                    clock.Start();
+                }
+
                 if (parsedSplit == null)
                 {
                     _log.Warn($"GetTreatment: you passed {featureName} that does not exist in this environment, please double check what Splits exist in the web console.");
 
-                    return new TreatmentResult(Labels.LabelSplitNotFound, Control, elapsedMilliseconds: clock.ElapsedMilliseconds);
+                    return new TreatmentResult(Labels.SplitNotFound, Control, elapsedMilliseconds: clock.ElapsedMilliseconds);
                 }
 
-                var treatmentResult = EvalTreatment(key, parsedSplit, attributes);
+                var treatmentResult = GetTreatmentResult(key, parsedSplit, attributes);
 
                 if (parsedSplit.configurations != null && parsedSplit.configurations.ContainsKey(treatmentResult.Treatment))
                 {
@@ -62,37 +121,15 @@ namespace Splitio.Services.Evaluator
             {
                 _log.Error($"Exception caught getting treatment for feature: {featureName}", e);
 
-                return new TreatmentResult(Labels.LabelException, Control, elapsedMilliseconds: clock.ElapsedMilliseconds);
+                return new TreatmentResult(Labels.Exception, Control, elapsedMilliseconds: clock.ElapsedMilliseconds);
             }
         }
 
-        public MultipleEvaluatorResult EvaluateFeatures(Key key, List<string> featureNames, Dictionary<string, object> attributes = null)
-        {
-            var treatmentsForFeatures = new Dictionary<string, TreatmentResult>();
-            var clock = new Stopwatch();
-            clock.Start();
-            
-            foreach (var feature in featureNames)
-            {
-                var result = EvaluateFeature(key, feature, attributes);
-
-                treatmentsForFeatures.Add(feature, result);
-            }
-
-            return new MultipleEvaluatorResult
-            {
-                TreatmentResults = treatmentsForFeatures,
-                ElapsedMilliseconds = clock.ElapsedMilliseconds
-            };
-        }
-        #endregion
-
-        #region Private Methods
-        private TreatmentResult EvalTreatment(Key key, ParsedSplit split, Dictionary<string, object> attributes = null)
+        private TreatmentResult GetTreatmentResult(Key key, ParsedSplit split, Dictionary<string, object> attributes = null)
         {
             if (split.killed)
             {
-                return new TreatmentResult(Labels.LabelKilled, split.defaultTreatment, split.changeNumber);
+                return new TreatmentResult(Labels.Killed, split.defaultTreatment, split.changeNumber);
             }
 
             var inRollout = false;
@@ -109,7 +146,7 @@ namespace Splitio.Services.Evaluator
 
                         if (bucket > split.trafficAllocation)
                         {
-                            return new TreatmentResult(Labels.LabelTrafficAllocationFailed, split.defaultTreatment, split.changeNumber);
+                            return new TreatmentResult(Labels.TrafficAllocationFailed, split.defaultTreatment, split.changeNumber);
                         }
                     }
 
@@ -126,7 +163,7 @@ namespace Splitio.Services.Evaluator
                 }
             }
 
-            return new TreatmentResult(Labels.LabelDefaultRule, split.defaultTreatment, split.changeNumber);   
+            return new TreatmentResult(Labels.DefaultRule, split.defaultTreatment, split.changeNumber);   
         }
         #endregion
     }

--- a/src/Splitio-net-core/Services/Shared/Classes/WrapperAdapter.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/WrapperAdapter.cs
@@ -17,38 +17,16 @@ namespace Splitio.Services.Shared.Classes
         public ReadConfigData ReadConfig(ConfigurationOptions config, ISplitLogger log)
         {
             var data = new ReadConfigData();
-
-            try
-            {
-                data.SdkMachineName = config.SdkMachineName ?? Environment.MachineName;
-            }
-            catch (Exception e)
-            {
-                data.SdkMachineName = "unknown";
-                log.Warn("Exception retrieving machine name.", e);
-            }
+            var ipAddressesEnabled = config.IPAddressesEnabled ?? true;
 
             data.SdkSpecVersion = ".NET-" + SplitSpecVersion();
-
-            try
-            {
 #if NETSTANDARD
-                data.SdkVersion = ".NET_CORE-" + SplitSdkVersion();                
-
-                var hostAddressesTask = Dns.GetHostAddressesAsync(Environment.MachineName);
-                hostAddressesTask.Wait();
-                data.SdkMachineIP = config.SdkMachineIP ?? hostAddressesTask.Result.Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();
+            data.SdkVersion = ".NET_CORE-" + SplitSdkVersion();
 #else
-                data.SdkVersion = ".NET-" + SplitSdkVersion();
-
-                data.SdkMachineIP = config.SdkMachineIP ?? Dns.GetHostAddresses(Environment.MachineName).Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();
+            data.SdkVersion = ".NET-" + SplitSdkVersion();
 #endif
-            }
-            catch (Exception e)
-            {
-                data.SdkMachineIP = "unknown";
-                log.Warn("Exception retrieving machine IP.", e);
-            }
+            data.SdkMachineName = GetSdkMachineName(config, ipAddressesEnabled, log);
+            data.SdkMachineIP = GetSdkMachineIP(config, ipAddressesEnabled, log);
 
             return data;
         }
@@ -98,9 +76,61 @@ namespace Splitio.Services.Shared.Classes
 #endif
         }
 
+        #region Private Methods
         private string SplitSpecVersion()
         {
             return "1.0";
         }
+
+        private string GetSdkMachineName(ConfigurationOptions config, bool ipAddressesEnabled, ISplitLogger log)
+        {
+            if (ipAddressesEnabled)
+            {
+                try
+                {
+                    return config.SdkMachineName ?? Environment.MachineName;
+                }
+                catch (Exception e)
+                {
+                    log.Warn("Exception retrieving machine name.", e);
+                    return "unknown";
+                }
+            }
+            else if(config.CacheAdapterConfig?.Type == AdapterType.Redis)
+            {
+                return "NA";
+            }
+
+            return string.Empty;
+        }
+
+        private string GetSdkMachineIP(ConfigurationOptions config, bool ipAddressesEnabled, ISplitLogger log)
+        {
+            if (ipAddressesEnabled)
+            {
+                try
+                {
+#if NETSTANDARD
+                    var hostAddressesTask = Dns.GetHostAddressesAsync(Environment.MachineName);
+                    hostAddressesTask.Wait();
+                    return config.SdkMachineIP ?? hostAddressesTask.Result.Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();
+#else
+                    return config.SdkMachineIP ?? Dns.GetHostAddresses(Environment.MachineName).Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();
+#endif
+                }
+                catch (Exception e)
+                {
+                    log.Warn("Exception retrieving machine IP.", e);
+                    return "unknown";
+                }
+            }
+            else if (config.CacheAdapterConfig?.Type == AdapterType.Redis)
+            {
+                return "NA";
+            }
+
+            return string.Empty;
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?

Added `IPAddressesEnabled` to enable/disable sending MachineName and MachineIP headers when data is posted to Split Servers.