### PR TITLE
Add setting to enable sending IP addresses (default should be ON)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@ CHANGES
 6.0.0 (Oct 30, 2019)
 - BREAKING CHANGE: Changed our logging framework implementation for .NET Core sdk. We use Microsoft.Extensions.Logging now.
 - Improved the performance of the getTreatments() and getTreatmentsWithConfig() call, by minimizing the amount of calls to redis when fetching splits.
+- Added IPAddressesEnabled to enable/disable sending MachineName and MachineIP headers when data is posted to Split Servers.
 
 5.0.3 (Oct 10, 2019)
 - Refactor Evaluator.

--- a/Splitio-net-core-tests/Unit Tests/Cache/RedisCacheBaseTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Cache/RedisCacheBaseTests.cs
@@ -118,7 +118,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             //Arrange
             var redisAdapterMock = new Mock<IRedisAdapter>();
             redisAdapterMock.Setup(x => x.IcrBy("SPLITIO/net-1.0.2/10.0.0.1/count.counter_test", 150)).Returns(150);
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             var result = cache.IncrementCount("counter_test", 150);
@@ -135,7 +135,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             //Arrange
             var redisAdapterMock = new Mock<IRedisAdapter>();
             redisAdapterMock.Setup(x => x.IcrBy("mycompany.SPLITIO/net-1.0.2/10.0.0.1/count.counter_test", 150)).Returns(150);
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "mycompany");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test", "mycompany");
 
             //Act
             var result = cache.IncrementCount("counter_test", 150);

--- a/Splitio-net-core-tests/Unit Tests/Cache/RedisImpressionCacheTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Cache/RedisImpressionCacheTests.cs
@@ -17,7 +17,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             //Arrange
             var key = "SPLITIO.impressions";
             var redisAdapterMock = new Mock<IRedisAdapter>();
-            var cache = new RedisImpressionsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisImpressionsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
             var impressions = new List<KeyImpression>
             {
                 new KeyImpression() { feature = "test", changeNumber = 100, keyName = "date", label = "testdate", time = 10000000 }

--- a/Splitio-net-core-tests/Unit Tests/Cache/RedisMetricsCacheTests.cs
+++ b/Splitio-net-core-tests/Unit Tests/Cache/RedisMetricsCacheTests.cs
@@ -1,12 +1,10 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Splitio.Services.Cache.Interfaces;
-using Splitio.Services.Cache.Classes;
-using Splitio.Services.Metrics.Interfaces;
-using System.Linq;
-using StackExchange.Redis;
 using Splitio.Redis.Services.Cache.Classes;
 using Splitio.Redis.Services.Cache.Interfaces;
+using Splitio.Services.Metrics.Interfaces;
+using StackExchange.Redis;
+using System.Linq;
 
 namespace Splitio_Tests.Unit_Tests.Cache
 {
@@ -23,7 +21,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             //Arrange
             var redisAdapterMock = new Mock<IRedisAdapter>();
             redisAdapterMock.Setup(x => x.IcrBy(metricsCountKeyPrefix + "counter_test", 150)).Returns(150);
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             var result = cache.IncrementCount("counter_test", 150);
@@ -42,7 +40,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.IcrBy(metricsCountKeyPrefix + "counter_test", 150)).Returns(150);
             redisAdapterMock.Setup(x => x.IcrBy(metricsCountKeyPrefix + "counter_test", 10)).Returns(160);
 
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.IncrementCount("counter_test", 150);
@@ -62,7 +60,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             var currentBucketPattern = bucketsPattern.Replace("*", "0");
             redisAdapterMock.Setup(x => x.Keys(bucketsPattern)).Returns(new RedisKey[]{ currentBucketPattern });
             redisAdapterMock.Setup(x => x.Get(currentBucketPattern)).Returns("1");
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.SetLatency("time_test", 1);
@@ -88,7 +86,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Keys(bucketsPattern)).Returns(new RedisKey[] { currentBucketPattern, currentBucketPattern2 });
             redisAdapterMock.Setup(x => x.Get(currentBucketPattern)).Returns("1");
             redisAdapterMock.Setup(x => x.Get(currentBucketPattern2)).Returns("2");
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.SetLatency("time_test", 1);
@@ -113,7 +111,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             var redisAdapterMock = new Mock<IRedisAdapter>();
             redisAdapterMock.Setup(x => x.Set(metricsGaugeKeyPrefix + "gauge_test", "150"));
             redisAdapterMock.Setup(x => x.Get(metricsGaugeKeyPrefix + "gauge_test")).Returns("150");
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.SetGauge("gauge_test", 150);
@@ -132,7 +130,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Set(metricsGaugeKeyPrefix + "gauge_test", "1234"));
             redisAdapterMock.Setup(x => x.Set(metricsGaugeKeyPrefix + "gauge_test", "4567"));
             redisAdapterMock.Setup(x => x.Get(metricsGaugeKeyPrefix + "gauge_test")).Returns("4567");
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
 
             //Act
             cache.SetGauge("gauge_test", 1234);
@@ -155,7 +153,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Get(metricsCountKeyPrefix + "counter_test")).Returns("150");
             redisAdapterMock.Setup(x => x.Get(metricsCountKeyPrefix + "counter_test_2")).Returns("124");
 
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
             cache.IncrementCount("counter_test", 150);
             cache.IncrementCount("counter_test_2", 123);
             cache.IncrementCount("counter_test_2", 1);
@@ -184,7 +182,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Get(metricsGaugeKeyPrefix + "gauge_test")).Returns("1234");
             redisAdapterMock.Setup(x => x.Get(metricsGaugeKeyPrefix + "gauge_test_1")).Returns("4567");
 
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
             cache.SetGauge("gauge_test", 1234);
             cache.SetGauge("gauge_test_1", 4567);
 
@@ -219,7 +217,7 @@ namespace Splitio_Tests.Unit_Tests.Cache
             redisAdapterMock.Setup(x => x.Get(currentBucketPattern3)).Returns("1");
 
 
-            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2");
+            var cache = new RedisMetricsCache(redisAdapterMock.Object, "10.0.0.1", "net-1.0.2", "machine_name_test");
             cache.SetLatency("time_test", 1);
             cache.SetLatency("time_test", 9);
             cache.SetLatency("time_test", 8);

--- a/Splitio-net-core.Integration-tests/BaseIntegrationTests.cs
+++ b/Splitio-net-core.Integration-tests/BaseIntegrationTests.cs
@@ -1083,7 +1083,7 @@ namespace Splitio_net_core.Integration_tests
             Assert.AreEqual(treatment, impression.treatment);
         }
         
-        protected abstract ConfigurationOptions GetConfigurationOptions(HttpClientMock httpClientMock = null, int? eventsPushRate = null, int? eventsQueueSize = null, int? featuresRefreshRate = null);
+        protected abstract ConfigurationOptions GetConfigurationOptions(HttpClientMock httpClientMock = null, int? eventsPushRate = null, int? eventsQueueSize = null, int? featuresRefreshRate = null, bool? ipAddressesEnabled = null);
 
         protected abstract void ShutdownServer(HttpClientMock httpClientMock = null);
 

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisCacheBase.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisCacheBase.cs
@@ -5,39 +5,49 @@ namespace Splitio.Redis.Services.Cache.Classes
     public abstract class RedisCacheBase
     {
         private const string RedisKeyPrefixFormat = "SPLITIO/{sdk-language-version}/{instance-id}/";
-        protected IRedisAdapter redisAdapter;
-        protected string redisKeyPrefix;
 
+        protected IRedisAdapter _redisAdapter;
+
+        protected string RedisKeyPrefix;
         protected string UserPrefix;
         protected string SdkVersion;
         protected string MachineIp;
+        protected string MachineName;
 
-        public RedisCacheBase(IRedisAdapter redisAdapter, string userPrefix = null)
+        public RedisCacheBase(IRedisAdapter redisAdapter, 
+            string userPrefix = null)
         {
+            _redisAdapter = redisAdapter;
+
             UserPrefix = userPrefix;
-            this.redisAdapter = redisAdapter;
-            redisKeyPrefix = "SPLITIO.";
+            RedisKeyPrefix = "SPLITIO.";
 
             if (!string.IsNullOrEmpty(userPrefix))
             {
-                redisKeyPrefix = userPrefix + "." + redisKeyPrefix;
+                RedisKeyPrefix = userPrefix + "." + RedisKeyPrefix;
             }
         }
 
-        public RedisCacheBase(IRedisAdapter redisAdapter, string machineIP, string sdkVersion, string userPrefix = null)
+        public RedisCacheBase(IRedisAdapter redisAdapter, 
+            string machineIP, 
+            string sdkVersion, 
+            string machineName, 
+            string userPrefix = null)
         {
+            _redisAdapter = redisAdapter;
+
             UserPrefix = userPrefix;
             MachineIp = machineIP;
             SdkVersion = sdkVersion;
+            MachineName = machineName;
 
-            this.redisAdapter = redisAdapter;
-            redisKeyPrefix = RedisKeyPrefixFormat
+            RedisKeyPrefix = RedisKeyPrefixFormat
                 .Replace("{sdk-language-version}", sdkVersion)
                 .Replace("{instance-id}", machineIP);
 
             if (!string.IsNullOrEmpty(userPrefix))
             {
-                redisKeyPrefix = userPrefix + "." + redisKeyPrefix;
+                RedisKeyPrefix = userPrefix + "." + RedisKeyPrefix;
             }
         }
     }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisEventsCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisEventsCache.cs
@@ -7,13 +7,15 @@ namespace Splitio.Redis.Services.Cache.Classes
 {
     public class RedisEventsCache : RedisCacheBase, ISimpleCache<WrappedEvent>
     {
-        private const string eventKeyPrefix = "events";
         private readonly string _machineName;
         private readonly string _machineIP;
         private readonly string _sdkVersion;
 
-        public RedisEventsCache(IRedisAdapter redisAdapter, string machineName, string machineIP, string sdkVersion, string userPrefix = null)
-            : base(redisAdapter, userPrefix) 
+        public RedisEventsCache(IRedisAdapter redisAdapter, 
+            string machineName,
+            string machineIP, 
+            string sdkVersion, 
+            string userPrefix = null) : base(redisAdapter, userPrefix) 
         {
             _machineName = machineName;
             _machineIP = machineIP;
@@ -22,13 +24,13 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public void AddItem(WrappedEvent item)
         {
-            var key = redisKeyPrefix + eventKeyPrefix;
             var eventJson = JsonConvert.SerializeObject(new
             {
                 m = new { s = _sdkVersion, i = _machineIP, n = _machineName },
                 e = item.Event
             });
-            redisAdapter.ListRightPush(key, eventJson);
+
+            _redisAdapter.ListRightPush($"{RedisKeyPrefix}events", eventJson);
         }
     }
 }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisImpressionsCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisImpressionsCache.cs
@@ -11,11 +11,12 @@ namespace Splitio.Redis.Services.Cache.Classes
 {
     public class RedisImpressionsCache : RedisCacheBase, ISimpleCache<IList<KeyImpression>>
     {
-        private const string impressionKeyPrefix = "impressions.";
-
-        public RedisImpressionsCache(IRedisAdapter redisAdapter, string machineIP, string sdkVersion, string userPrefix = null)
-            : base(redisAdapter, machineIP, sdkVersion, userPrefix) 
-        {}
+        public RedisImpressionsCache(IRedisAdapter redisAdapter, 
+            string machineIP, 
+            string sdkVersion, 
+            string machineName, 
+            string userPrefix = null) : base(redisAdapter, machineIP, sdkVersion, machineName, userPrefix) 
+        { }
 
         public void AddItem(IList<KeyImpression> items)
         {
@@ -23,15 +24,15 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             var impressions = items.Select(item => JsonConvert.SerializeObject(new
             {
-                m = new { s = SdkVersion, i = MachineIp, n = Environment.MachineName },
+                m = new { s = SdkVersion, i = MachineIp, n = MachineName },
                 i = new { k = item.keyName, b = item.bucketingKey, f = item.feature, t = item.treatment, r = item.label, c = item.changeNumber, m = item.time }
             }));
 
-            var lengthRedis = redisAdapter.ListRightPush(key, impressions.Select(i => (RedisValue)i).ToArray());
+            var lengthRedis = _redisAdapter.ListRightPush(key, impressions.Select(i => (RedisValue)i).ToArray());
 
             if (lengthRedis == items.Count)
             {
-                redisAdapter.KeyExpire(key, new TimeSpan(0, 0, 3600));
+                _redisAdapter.KeyExpire(key, new TimeSpan(0, 0, 3600));
             }
         }
     }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisMetricsCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisMetricsCache.cs
@@ -9,22 +9,25 @@ namespace Splitio.Redis.Services.Cache.Classes
 {
     public class RedisMetricsCache : RedisCacheBase, IMetricsCache
     {
-        private ILatencyTracker latencyTracker;
         private const string metricsLatencyKeyPrefix = "latency.{metricName}.bucket.{bucketNumber}";
         private const string metricsCountKeyPrefix = "count.";
         private const string metricsGaugeKeyPrefix = "gauge.";
 
-        public RedisMetricsCache(IRedisAdapter redisAdapter, string machineIP, string sdkVersion, string userPrefix = null)
-            : base(redisAdapter, machineIP, sdkVersion, userPrefix) 
+        private readonly ILatencyTracker _latencyTracker;        
+
+        public RedisMetricsCache(IRedisAdapter redisAdapter, 
+            string machineIP, 
+            string sdkVersion, 
+            string machineName, 
+            string userPrefix = null) : base(redisAdapter, machineIP, sdkVersion, machineName, userPrefix) 
         {
-            this.latencyTracker = new BinarySearchLatencyTracker();       
+            _latencyTracker = new BinarySearchLatencyTracker();       
         }
 
         public Counter IncrementCount(string name, long delta)
         {
-            var key = redisKeyPrefix + metricsCountKeyPrefix + name;
-            var result = redisAdapter.IcrBy(key, delta);
-
+            var key = $"{RedisKeyPrefix}{metricsCountKeyPrefix}{name}";
+            var result = _redisAdapter.IcrBy(key, delta);
             var counter = new Counter(); //TODO: counter.count is losing its original value!!
             counter.AddDelta(result);
 
@@ -33,8 +36,8 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public Counter GetCount(string name)
         {
-            var key = redisKeyPrefix + metricsCountKeyPrefix + name;
-            var result = redisAdapter.Get(key);
+            var key = $"{RedisKeyPrefix}{metricsCountKeyPrefix}{name}";
+            var result = _redisAdapter.Get(key);
             var counter = new Counter(); //TODO: counter.count is losing its original value!!
             counter.AddDelta(long.Parse(result));
 
@@ -44,29 +47,34 @@ namespace Splitio.Redis.Services.Cache.Classes
         public Dictionary<string, Counter> FetchAllCountersAndClear()
         {
             var result = new Dictionary<string, Counter>();
-            var pattern = redisKeyPrefix + metricsCountKeyPrefix + "*";
-            var keys = redisAdapter.Keys(pattern);
+            var pattern = $"{RedisKeyPrefix}{metricsCountKeyPrefix}*";
+            var keys = _redisAdapter.Keys(pattern);
+
             foreach (var count in keys)
             {
-                var value = redisAdapter.Get(count);
-                var countName = ((string)count).Replace(redisKeyPrefix + metricsCountKeyPrefix, "");
+                var value = _redisAdapter.Get(count);
+                var countName = ((string)count).Replace(RedisKeyPrefix + metricsCountKeyPrefix, "");
                 var counterValue = long.Parse(value);
+
                 result.Add(countName, new Counter(counterValue)); //TODO: counter.count is losing its original value!!
-                redisAdapter.Del(count);
+
+                _redisAdapter.Del(count);
             }
+
             return result;
         }
 
         public void SetGauge(string name, long gauge)
         {
-            var key = redisKeyPrefix + metricsGaugeKeyPrefix + name;
-            redisAdapter.Set(key, gauge.ToString());
+            var key = $"{RedisKeyPrefix}{metricsGaugeKeyPrefix}{name}";
+
+            _redisAdapter.Set(key, gauge.ToString());
         }
 
         public long GetGauge(string name)
         {
-            var key = redisKeyPrefix + metricsGaugeKeyPrefix + name;
-            string value = redisAdapter.Get(key);
+            var key = $"{RedisKeyPrefix}{metricsGaugeKeyPrefix}{name}";
+            var value = _redisAdapter.Get(key);
 
             return long.Parse(value);
         }
@@ -74,47 +82,57 @@ namespace Splitio.Redis.Services.Cache.Classes
         public Dictionary<string, long> FetchAllGaugesAndClear()
         {
             var result = new Dictionary<string, long>();
-            var pattern = redisKeyPrefix + metricsGaugeKeyPrefix + "*";
-            var keys = redisAdapter.Keys(pattern);
+            var pattern = $"{RedisKeyPrefix}{metricsGaugeKeyPrefix}*";
+            var keys = _redisAdapter.Keys(pattern);
+
             foreach (var gauge in keys)
             {
-                var value = redisAdapter.Get(gauge);
-                var gaugeName = ((string)gauge).Replace(redisKeyPrefix + metricsGaugeKeyPrefix, "");
+                var value = _redisAdapter.Get(gauge);
+                var gaugeName = ((string)gauge).Replace(RedisKeyPrefix + metricsGaugeKeyPrefix, "");
+
                 result.Add(gaugeName, long.Parse(value));
-                redisAdapter.Del(gauge);
+
+                _redisAdapter.Del(gauge);
             }
+
             return result;
         }
 
         public void SetLatency(string name, long value)
         {
-            var bucketToIncrement = ((BinarySearchLatencyTracker)latencyTracker).FindIndex(value * 1000);
-            var key = redisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}", name).Replace("{bucketNumber}", bucketToIncrement.ToString());
-            var result = redisAdapter.IcrBy(key, 1);
+            var bucketToIncrement = ((BinarySearchLatencyTracker)_latencyTracker).FindIndex(value * 1000);
+            var key = RedisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}", name).Replace("{bucketNumber}", bucketToIncrement.ToString());
+
+            _redisAdapter.IcrBy(key, 1);
         }
 
         public ILatencyTracker GetLatencyTracker(string name)
         {
-            var bucketsPattern = redisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}", name).Replace("{bucketNumber}", "*");
-            var keys = redisAdapter.Keys(bucketsPattern);
             ILatencyTracker result = new BinarySearchLatencyTracker();
+
+            var bucketsPattern = RedisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}", name).Replace("{bucketNumber}", "*");
+            var keys = _redisAdapter.Keys(bucketsPattern);
+            
             foreach (var key in keys)
             {
                 var bucketPrefix = bucketsPattern.Replace("*", "");
                 var bucket = ((string)key).Replace(bucketPrefix, "");
                 var currentBucketPattern = bucketsPattern.Replace("*", bucket);
-                var valueString = redisAdapter.Get(currentBucketPattern);
-                long value = long.Parse(valueString);
+                var valueString = _redisAdapter.Get(currentBucketPattern);
+                var value = long.Parse(valueString);
+
                 result.SetLatencyCount(int.Parse(bucket), value);
             }
+
             return result;
         }
 
         public Dictionary<string, ILatencyTracker> FetchAllLatencyTrackersAndClear()
         {
             var result = new Dictionary<string, ILatencyTracker>();
-            var pattern = redisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}.bucket.{bucketNumber}", "*");
-            var keys = redisAdapter.Keys(pattern);
+            var pattern = RedisKeyPrefix + metricsLatencyKeyPrefix.Replace("{metricName}.bucket.{bucketNumber}", "*");
+            var keys = _redisAdapter.Keys(pattern);
+
             foreach(var key in keys)
             {
                 var keyParts = ((string)key).Split(new Char[]{'.', '/'});
@@ -123,21 +141,22 @@ namespace Splitio.Redis.Services.Cache.Classes
                 string name = keyParts[latencyPosition + 1];
                 string bucket = keyParts[bucketPosition + 1];
 
-                ILatencyTracker tracker;
-                result.TryGetValue(name, out tracker);
+                result.TryGetValue(name, out ILatencyTracker tracker);
+
                 if (tracker == null)
                 {
                     tracker = new BinarySearchLatencyTracker();                
                     result.Add(name, tracker);
                 }
 
-                var valueString = redisAdapter.Get(key);
-                long value = long.Parse(valueString);
+                var valueString = _redisAdapter.Get(key);
+                var value = long.Parse(valueString);
                 
                 tracker.SetLatencyCount(int.Parse(bucket), value);
 
-                redisAdapter.Del(key);
+                _redisAdapter.Del(key);
             }
+
             return result;
         }      
     }

--- a/Splitio-net-core.Redis/Services/Cache/Classes/RedisSplitCache.cs
+++ b/Splitio-net-core.Redis/Services/Cache/Classes/RedisSplitCache.cs
@@ -26,8 +26,8 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public long GetChangeNumber()
         {
-            var key = redisKeyPrefix + splitsKeyPrefix + "till";
-            var changeNumberString = redisAdapter.Get(key);
+            var key = $"{RedisKeyPrefix}{splitsKeyPrefix}till";
+            var changeNumberString = _redisAdapter.Get(key);
             var result = long.TryParse(changeNumberString, out long changeNumberParsed);
             
             return result ? changeNumberParsed : -1;
@@ -35,8 +35,8 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public ParsedSplit GetSplit(string splitName)
         {
-            var key = redisKeyPrefix + splitKeyPrefix + splitName;
-            var splitJson = redisAdapter.Get(key);
+            var key = $"{RedisKeyPrefix}{splitKeyPrefix}{splitName}";
+            var splitJson = _redisAdapter.Get(key);
 
             if (string.IsNullOrEmpty(splitJson))
                 return null;
@@ -48,9 +48,9 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public List<ParsedSplit> GetAllSplits()
         {
-            var pattern = redisKeyPrefix + splitKeyPrefix + "*";
-            var splitKeys = redisAdapter.Keys(pattern);
-            var splitValues = redisAdapter.MGet(splitKeys);
+            var pattern = $"{RedisKeyPrefix}{splitKeyPrefix}*";
+            var splitKeys = _redisAdapter.Keys(pattern);
+            var splitValues = _redisAdapter.MGet(splitKeys);
 
             if (splitValues != null && splitValues.Any())
             {
@@ -68,8 +68,8 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         public List<string> GetKeys()
         {
-            var pattern = redisKeyPrefix + splitKeyPrefix + "*";
-            var splitKeys = redisAdapter.Keys(pattern);
+            var pattern = $"{RedisKeyPrefix}{splitKeyPrefix}*";
+            var splitKeys = _redisAdapter.Keys(pattern);
             var result = splitKeys.Select(x => x.ToString()).ToList();
 
             return result;
@@ -84,7 +84,7 @@ namespace Splitio.Redis.Services.Cache.Classes
         {
             if (string.IsNullOrEmpty(trafficType)) return false;
 
-            var value = redisAdapter.Get(GetTrafficTypeKey(trafficType));
+            var value = _redisAdapter.Get(GetTrafficTypeKey(trafficType));
 
             var quantity = value ?? "0";
 
@@ -95,7 +95,7 @@ namespace Splitio.Redis.Services.Cache.Classes
 
         private string GetTrafficTypeKey(string type)
         {
-            return $"{redisKeyPrefix}trafficType.{type}";
+            return $"{RedisKeyPrefix}trafficType.{type}";
         }
 
         public void AddSplit(string splitName, SplitBase split)
@@ -136,10 +136,10 @@ namespace Splitio.Redis.Services.Cache.Classes
 
             foreach (var name in splitNames)
             {
-                redisKey.Add($"{redisKeyPrefix}{splitKeyPrefix}{name}");
+                redisKey.Add($"{RedisKeyPrefix}{splitKeyPrefix}{name}");
             }
                         
-            var splitValues = redisAdapter.MGet(redisKey.ToArray());
+            var splitValues = _redisAdapter.MGet(redisKey.ToArray());
 
             if (splitValues == null || !splitValues.Any()) return new List<ParsedSplit>();
 

--- a/Splitio-net-core.Redis/Services/Client/Classes/RedisClient.cs
+++ b/Splitio-net-core.Redis/Services/Client/Classes/RedisClient.cs
@@ -97,8 +97,8 @@ namespace Splitio.Redis.Services.Client.Classes
             BuildParser();
             splitCache = new RedisSplitCache(redisAdapter, _splitParser, RedisUserPrefix);
             
-            metricsCache = new RedisMetricsCache(redisAdapter, SdkMachineIP, SdkVersion, RedisUserPrefix);
-            impressionsCacheRedis = new RedisImpressionsCache(redisAdapter, SdkMachineIP, SdkVersion, RedisUserPrefix);
+            metricsCache = new RedisMetricsCache(redisAdapter, SdkMachineIP, SdkVersion, SdkMachineName, RedisUserPrefix);
+            impressionsCacheRedis = new RedisImpressionsCache(redisAdapter, SdkMachineIP, SdkVersion, SdkMachineName, RedisUserPrefix);
             eventsCache = new RedisEventsCache(redisAdapter, SdkMachineName, SdkMachineIP, SdkVersion, RedisUserPrefix);
 
             _trafficTypeValidator = new TrafficTypeValidator(splitCache);

--- a/src/Splitio-net-core/Services/Client/Classes/ConfigurationOptions.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/ConfigurationOptions.cs
@@ -28,5 +28,6 @@ namespace Splitio.Services.Client.Classes
         public bool? LabelsEnabled { get; set; }
         public IImpressionListener ImpressionListener { get; set; }
         public CacheAdapterConfigurationOptions CacheAdapterConfig { get; set; }
+        public bool? IPAddressesEnabled { get; set; }
     }
 }

--- a/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/src/Splitio-net-core/Services/Client/Classes/SelfRefreshingClient.cs
@@ -170,6 +170,7 @@ namespace Splitio.Services.Client.Classes
             treatmentLog = new SelfUpdatingTreatmentLog(treatmentSdkApiClient, TreatmentLogRefreshRate, impressionsCache);
             impressionListener = new AsynchronousListener<KeyImpression>(WrapperAdapter.GetLogger("AsynchronousImpressionListener"));
             ((IAsynchronousListener<KeyImpression>)impressionListener).AddListener(treatmentLog);
+
             if (config.ImpressionListener != null)
             {
                 ((IAsynchronousListener<KeyImpression>)impressionListener).AddListener(config.ImpressionListener);
@@ -198,12 +199,15 @@ namespace Splitio.Services.Client.Classes
 
         private void BuildSdkApiClients()
         {
-            var header = new HTTPHeader();
-            header.authorizationApiKey = ApiKey;
-            header.splitSDKVersion = SdkVersion;
-            header.splitSDKSpecVersion = SdkSpecVersion;
-            header.splitSDKMachineName = SdkMachineName;
-            header.splitSDKMachineIP = SdkMachineIP;
+            var header = new HTTPHeader
+            {
+                authorizationApiKey = ApiKey,
+                splitSDKVersion = SdkVersion,
+                splitSDKSpecVersion = SdkSpecVersion,
+                splitSDKMachineName = SdkMachineName,
+                splitSDKMachineIP = SdkMachineIP
+            };
+
             metricsSdkApiClient = new MetricsSdkApiClient(header, EventsBaseUrl, HttpConnectionTimeout, HttpReadTimeout);
             BuildMetricsLog();
             splitSdkApiClient = new SplitSdkApiClient(header, BaseUrl, HttpConnectionTimeout, HttpReadTimeout, metricsLog);

--- a/src/Splitio-net-core/Services/Shared/Classes/WrapperAdapter.cs
+++ b/src/Splitio-net-core/Services/Shared/Classes/WrapperAdapter.cs
@@ -17,38 +17,16 @@ namespace Splitio.Services.Shared.Classes
         public ReadConfigData ReadConfig(ConfigurationOptions config, ISplitLogger log)
         {
             var data = new ReadConfigData();
-
-            try
-            {
-                data.SdkMachineName = config.SdkMachineName ?? Environment.MachineName;
-            }
-            catch (Exception e)
-            {
-                data.SdkMachineName = "unknown";
-                log.Warn("Exception retrieving machine name.", e);
-            }
+            var ipAddressesEnabled = config.IPAddressesEnabled ?? true;
 
             data.SdkSpecVersion = ".NET-" + SplitSpecVersion();
-
-            try
-            {
 #if NETSTANDARD
-                data.SdkVersion = ".NET_CORE-" + SplitSdkVersion();                
-
-                var hostAddressesTask = Dns.GetHostAddressesAsync(Environment.MachineName);
-                hostAddressesTask.Wait();
-                data.SdkMachineIP = config.SdkMachineIP ?? hostAddressesTask.Result.Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();
+            data.SdkVersion = ".NET_CORE-" + SplitSdkVersion();
 #else
-                data.SdkVersion = ".NET-" + SplitSdkVersion();
-
-                data.SdkMachineIP = config.SdkMachineIP ?? Dns.GetHostAddresses(Environment.MachineName).Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();
+            data.SdkVersion = ".NET-" + SplitSdkVersion();
 #endif
-            }
-            catch (Exception e)
-            {
-                data.SdkMachineIP = "unknown";
-                log.Warn("Exception retrieving machine IP.", e);
-            }
+            data.SdkMachineName = GetSdkMachineName(config, ipAddressesEnabled, log);
+            data.SdkMachineIP = GetSdkMachineIP(config, ipAddressesEnabled, log);
 
             return data;
         }
@@ -98,9 +76,61 @@ namespace Splitio.Services.Shared.Classes
 #endif
         }
 
+        #region Private Methods
         private string SplitSpecVersion()
         {
             return "1.0";
         }
+
+        private string GetSdkMachineName(ConfigurationOptions config, bool ipAddressesEnabled, ISplitLogger log)
+        {
+            if (ipAddressesEnabled)
+            {
+                try
+                {
+                    return config.SdkMachineName ?? Environment.MachineName;
+                }
+                catch (Exception e)
+                {
+                    log.Warn("Exception retrieving machine name.", e);
+                    return "unknown";
+                }
+            }
+            else if(config.CacheAdapterConfig?.Type == AdapterType.Redis)
+            {
+                return "NA";
+            }
+
+            return string.Empty;
+        }
+
+        private string GetSdkMachineIP(ConfigurationOptions config, bool ipAddressesEnabled, ISplitLogger log)
+        {
+            if (ipAddressesEnabled)
+            {
+                try
+                {
+#if NETSTANDARD
+                    var hostAddressesTask = Dns.GetHostAddressesAsync(Environment.MachineName);
+                    hostAddressesTask.Wait();
+                    return config.SdkMachineIP ?? hostAddressesTask.Result.Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();
+#else
+                    return config.SdkMachineIP ?? Dns.GetHostAddresses(Environment.MachineName).Where(x => x.AddressFamily == AddressFamily.InterNetwork && x.IsIPv6LinkLocal == false).Last().ToString();
+#endif
+                }
+                catch (Exception e)
+                {
+                    log.Warn("Exception retrieving machine IP.", e);
+                    return "unknown";
+                }
+            }
+            else if (config.CacheAdapterConfig?.Type == AdapterType.Redis)
+            {
+                return "NA";
+            }
+
+            return string.Empty;
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
# .NET SDK

## What did you accomplish?
Added IPAddressesEnabled to enable/disable sending MachineName and MachineIP headers when data is posted to Split Servers.
