### PR TITLE
Remove .Net 4 dependency on YamlDotNet.Signed

### DIFF
--- a/src/Splitio-net-core/Splitio.csproj
+++ b/src/Splitio-net-core/Splitio.csproj
@@ -48,7 +48,6 @@
     <PackageReference Include="murmurhash-signed" version="1.0.2" />
     <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
     <PackageReference Include="YamlDotNet" version="6.0.0" />
-    <PackageReference Include="YamlDotNet.Signed" version="6.0.0" />
   </ItemGroup>  
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">


### PR DESCRIPTION
The YamlDotNet.Signed package is no longer available to install, as of 6.0.0.
See https://github.com/aaubry/YamlDotNet/blob/master/releases/6.0.0.md 
Removing the dependency.
# .NET SDK

## What did you accomplish?
Fixes build when installing split-io on .Net Framework Apps
## How do we test the changes introduced in this PR?
Install on .Net Framework 4.0+
## Extra Notes